### PR TITLE
fix(ai-review-gate): accept Codex summaries by head-commit timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ node_modules/
 .unicorn-hub/local.json
 .claude/worktrees/
 .claude/settings.local.json
+.codex/
+.omc/
 dist/
 coverage/

--- a/docs/github-ci-and-branch-protection.md
+++ b/docs/github-ci-and-branch-protection.md
@@ -14,7 +14,7 @@ GitHub is the control plane for pull requests, checks, and AI review routing.
 
 - Unsupported `AI_REVIEW_AGENT` values fail the check.
 - Missing review evidence fails the check.
-- Review evidence must match the current PR head SHA, including any accepted Codex no-findings summary comment.
+- Review evidence must be bound to the current PR head SHA. Native reviews compare `commit_id` to head; trusted no-findings Codex summaries must either name the head SHA or be posted at or after the head commit timestamp.
 - Gate scripts must run from the trusted default branch, not PR-supplied code.
 - Skipped required gates must not be used as a successful state.
 

--- a/scripts/ai-review-gate.mjs
+++ b/scripts/ai-review-gate.mjs
@@ -85,6 +85,11 @@ async function maybePostTriggerComment() {
   ].join("\n"));
 }
 
+async function fetchHeadCommittedAt() {
+  const commit = await request(`/repos/${owner}/${repo}/commits/${headSha}`);
+  return commit?.commit?.committer?.date || null;
+}
+
 async function fetchEvidence() {
   if (selectedAgent === "claude") {
     const comments = await listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`);
@@ -105,9 +110,10 @@ async function fetchEvidence() {
 
   if (selectedAgent !== "codex") return false;
 
+  const headCommittedAt = await fetchHeadCommittedAt();
   const comments = await listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`);
   return comments.some((comment) =>
-    isAcceptableCodexSummaryComment(comment, headSha, config)
+    isAcceptableCodexSummaryComment(comment, headSha, headCommittedAt, config)
   );
 }
 

--- a/scripts/ai-review-helpers.mjs
+++ b/scripts/ai-review-helpers.mjs
@@ -52,15 +52,19 @@ export function extractCodexPriority(body) {
   return match ? Number(match[1]) : null;
 }
 
-export function isAcceptableCodexSummaryComment(comment, headSha, config = {}) {
+export function isAcceptableCodexSummaryComment(comment, headSha, headCommittedAt = null, config = {}) {
   const body = String(comment?.body || "").trim();
   const login = normalizeLogin(comment?.user?.login);
+  if (!isTrustedReviewLogin(login, "codex", config)) return false;
+  if (!/^Codex Review:/i.test(body)) return false;
+  if (!/did(?:\s+not|\s*n['’]?t)\s+find\s+any\s+major\s+issues/i.test(body)) return false;
+
   const shortSha = String(headSha || "").slice(0, 10);
-  return isTrustedReviewLogin(login, "codex", config) &&
-    /^Codex Review:/i.test(body) &&
-    Boolean(shortSha) &&
-    (body.includes(headSha) || body.includes(shortSha)) &&
-    /did(?:\s+not|\s*n['’]?t)\s+find\s+any\s+major\s+issues/i.test(body);
+  if (shortSha && (body.includes(headSha) || body.includes(shortSha))) return true;
+
+  const committedAt = Date.parse(headCommittedAt || "");
+  const createdAt = Date.parse(comment?.created_at || "");
+  return Number.isFinite(committedAt) && Number.isFinite(createdAt) && createdAt >= committedAt;
 }
 
 export function classifyCodexNativeReview(review, reviewComments = [], headSha, config = {}) {

--- a/scripts/shared.mjs
+++ b/scripts/shared.mjs
@@ -60,6 +60,7 @@ export function walkFiles(root, options = {}) {
     ".git",
     ".claude",
     ".codex",
+    ".omc",
     "node_modules",
     "dist",
     "coverage",

--- a/specs/004-codex-summary-timestamp-binding/plan.md
+++ b/specs/004-codex-summary-timestamp-binding/plan.md
@@ -1,0 +1,33 @@
+# Plan: Codex Summary Comment Timestamp Binding
+
+## Summary
+
+`isAcceptableCodexSummaryComment` previously required the no-findings comment body to literally contain the head SHA. The live `chatgpt-codex-connector[bot]` Codex Cloud format does not include a SHA, so that path was unsatisfiable and the gate fell through to its 20-minute timeout on every PR. Add a timestamp-binding fallback: accept a trusted `Codex Review: ... did not find any major issues` comment whose `created_at` is at or after the head commit's `committer.date`. Keep the SHA-in-body fast path so future Codex format changes that include the SHA continue to pass without consulting the commit endpoint.
+
+## Technical Context
+
+- Affected scripts: `scripts/ai-review-helpers.mjs`, `scripts/ai-review-gate.mjs`.
+- New API call: `GET /repos/{owner}/{repo}/commits/{headSha}` to read `commit.committer.date`. Reused from the existing `request` helper, scoped to the Codex summary-comment fallback only.
+- Doc updates: `templates/docs_project/project/devops/review-contract.md` (canonical contract for installed targets) and `docs/github-ci-and-branch-protection.md` (operator-facing fail-closed rules).
+- Sanitizer hardening: `scripts/shared.mjs` `walkFiles` ignored set gains `.omc` so local OMC plugin metadata does not break the sanitizer subprocess invoked by `tests/sanitizer.test.mjs`. `.gitignore` mirrors that intent and adds `.codex/`.
+
+## Constitution Check
+
+- Spec-first: this folder lands together with the implementation in the same PR.
+- Testable boundaries: `tests/helpers.test.mjs` covers acceptance at the head commit boundary and stale-comment rejection. `pnpm run preflight` is the gate.
+- PR-only: all changes ship through the fix branch.
+- Simplicity: one helper signature change, one new function in the gate, no new modules. Stale-comment defence is preserved via timestamp comparison rather than the unsatisfiable SHA-in-body requirement.
+- Deployability: gate scripts continue to run from the trusted default branch per `ai-review.yml`. No workflow surface changes.
+
+## Complexity Tracking
+
+`headCommittedAt` is added as an explicit positional argument to `isAcceptableCodexSummaryComment`. Existing callers and tests that omit it remain on the SHA-in-body path through the default `null` value, so no other internal call sites need updating.
+
+## Verification
+
+- `pnpm run preflight`
+- Re-trigger `AI Review` on the unblocking PR via `gh workflow run ai-review.yml -f pr_number=<PR> -f trigger_mode=skip` after the fix lands on the default branch.
+
+## Risks
+
+- Force-pushing a PR backwards to a commit whose `committer.date` predates an existing stale Codex summary comment would let that stale comment satisfy the new path. Mitigated by the trusted-bot login requirement and the `Codex Review: ... did not find any major issues` body pattern, plus the rarity of intentional backward force-pushes on protected branches. Documented as accepted residual risk in the contract docs.

--- a/specs/004-codex-summary-timestamp-binding/spec.md
+++ b/specs/004-codex-summary-timestamp-binding/spec.md
@@ -1,0 +1,19 @@
+# Spec: Codex Summary Comment Timestamp Binding
+
+## User Stories
+
+### US1: Codex No-Findings Path Is Reachable in Production
+
+As a repository owner, I want the AI Review gate to accept the actual no-findings response from `chatgpt-codex-connector[bot]`, so that PRs do not stall for 20 minutes waiting on an unsatisfiable summary-comment match when Codex Cloud has already approved the change.
+
+## Requirements
+
+- FR-010a: A trusted no-findings `Codex Review:` summary comment satisfies the gate when its `created_at` is at or after the head commit's `committer.date`.
+- FR-010b: The pre-existing SHA-in-body fast path continues to satisfy the gate without consulting timestamps.
+- FR-010c: Stale no-findings summaries from prior heads, identified by `created_at` strictly before the head commit timestamp, must not satisfy the gate.
+
+## Success Criteria
+
+- SC-001: `pnpm run preflight` passes locally on the fix branch.
+- SC-002: `tests/helpers.test.mjs` covers the at-or-after timestamp acceptance, the stale-comment rejection, and preserves the existing SHA-in-body acceptance.
+- SC-003: After the fix lands on the default branch, re-triggering `AI Review` on a PR whose only Codex evidence is the generic `Codex Review: Didn't find any major issues. Can't wait for the next one!` comment passes the gate without further intervention.

--- a/specs/004-codex-summary-timestamp-binding/tasks.md
+++ b/specs/004-codex-summary-timestamp-binding/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: Codex Summary Comment Timestamp Binding
+
+## Implementation
+
+- [x] Extend `isAcceptableCodexSummaryComment` in `scripts/ai-review-helpers.mjs` to accept `(comment, headSha, headCommittedAt = null, config = {})` and add a timestamp-binding fallback after the SHA-in-body fast path.
+- [x] Add `fetchHeadCommittedAt` to `scripts/ai-review-gate.mjs` and thread the result into the Codex summary-comment scan.
+- [x] Update `templates/docs_project/project/devops/review-contract.md` and `docs/github-ci-and-branch-protection.md` to reflect the at-or-after timestamp acceptance.
+
+## Local Hygiene
+
+- [x] Add `.omc` to the `walkFiles` ignored set in `scripts/shared.mjs` so the sanitizer ignores local OMC plugin metadata.
+- [x] Add `.omc/` and `.codex/` to `.gitignore` so contributors do not accidentally commit per-checkout tool state.
+
+## Verification
+
+- [x] Add timestamp-binding test cases (acceptance at and after head commit, rejection for stale comment) to `tests/helpers.test.mjs`.
+- [x] Run `pnpm run preflight`.
+- [ ] Re-trigger `AI Review` on https://github.com/kiaquila/unicorn-hub/pull/3 after merge to confirm the gate passes against the existing Codex no-findings comment.

--- a/templates/docs_project/project/devops/review-contract.md
+++ b/templates/docs_project/project/devops/review-contract.md
@@ -4,7 +4,7 @@
 
 Native GitHub PR review. Blocking findings use `P0`, `P1`, or `P2`. Advisory findings use `P3`.
 
-When Codex has no inline findings, a top-level `Codex Review:` summary comment from the trusted Codex bot also satisfies the gate only if it names the current head SHA.
+When Codex has no inline findings, a top-level `Codex Review:` summary comment from the trusted Codex bot also satisfies the gate, provided it either names the current head SHA in its body or was posted at or after the head commit timestamp (so stale summaries from prior heads cannot pass).
 
 ## Claude
 

--- a/tests/helpers.test.mjs
+++ b/tests/helpers.test.mjs
@@ -106,6 +106,37 @@ test("Codex no-findings summary comment is accepted from trusted bot only", () =
   );
 });
 
+test("Codex no-findings summary is accepted when posted at-or-after the head commit", () => {
+  const headCommittedAt = "2026-04-29T19:29:46Z";
+
+  assert.equal(
+    isAcceptableCodexSummaryComment({
+      body: "Codex Review: Didn't find any major issues. Can't wait for the next one!",
+      user: { login: "chatgpt-codex-connector[bot]" },
+      created_at: "2026-04-29T19:32:55Z"
+    }, "abc123def456", headCommittedAt),
+    true
+  );
+
+  assert.equal(
+    isAcceptableCodexSummaryComment({
+      body: "Codex Review: Didn't find any major issues. Can't wait for the next one!",
+      user: { login: "chatgpt-codex-connector[bot]" },
+      created_at: "2026-04-29T19:29:46Z"
+    }, "abc123def456", headCommittedAt),
+    true
+  );
+
+  assert.equal(
+    isAcceptableCodexSummaryComment({
+      body: "Codex Review: Didn't find any major issues on a stale head.",
+      user: { login: "chatgpt-codex-connector[bot]" },
+      created_at: "2026-04-29T19:00:00Z"
+    }, "abc123def456", headCommittedAt),
+    false
+  );
+});
+
 test("Codex commented reviews are classified by inline priorities", () => {
   const review = {
     id: 123,


### PR DESCRIPTION
## Summary

- The Codex Cloud Connector posts no-findings summaries without the head SHA, so `isAcceptableCodexSummaryComment`'s SHA-in-body requirement made that gate path unsatisfiable in production. Every PR was falling through to the 20-min `AI Review` timeout (see https://github.com/kiaquila/unicorn-hub/pull/3 for the symptom).
- Add a timestamp-binding fallback: a trusted `Codex Review: ... did not find any major issues` summary now satisfies the gate when its `created_at` is at or after the head commit's `committer.date`. The SHA-in-body fast path still wins when present.
- Stale-comment defence preserved: comments posted before the head commit timestamp are rejected.
- Spec/plan/tasks added at `specs/004-codex-summary-timestamp-binding/`. Contract docs updated in `templates/docs_project/project/devops/review-contract.md` and `docs/github-ci-and-branch-protection.md`.
- Local hygiene: `.omc/` added to `walkFiles` ignored set and `.gitignore` (plus `.codex/` in `.gitignore`) so OMC plugin metadata stops tripping the sanitizer subprocess in `tests/sanitizer.test.mjs`.

## Known chicken-and-egg

This PR's own `AI Review` gate will fail for the same reason — the workflow checks out gate scripts from `main`, which still contains the broken contract. Admin-merge through the failing check; once this lands, re-trigger PR #3 via:

\`\`\`
gh workflow run ai-review.yml -f pr_number=3 -f trigger_mode=skip
\`\`\`

## Test plan

- [x] \`pnpm run preflight\` passes locally (17/17 tests).
- [x] New \`tests/helpers.test.mjs\` cases cover acceptance at the boundary, acceptance after, and stale-comment rejection.
- [x] Existing test block (no \`headCommittedAt\`) still passes via the SHA-in-body path.
- [ ] After merge: re-trigger AI Review on PR #3 and confirm gate passes against the existing 19:32:55Z Codex no-findings comment for head \`740109e\`.