### PR TITLE
[codex] Add Flutter bootstrap profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ node_modules/
 .claude/settings.local.json
 .codex/
 .omc/
+.omx/
 dist/
 coverage/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ node /path/to/unicorn-hub/scripts/bootstrap-repo.mjs \
 
 Profiles live in [`profiles/`](./profiles). If no profile fits, use `generic` values in `.unicorn-hub/config.json` after bootstrapping.
 
+Current profiles include:
+
+- `generic`: fallback for repositories that need manual command adaptation
+- `next-app`: Next.js applications with TypeScript and hosted previews
+- `python-service`: Python services with API or worker entrypoints
+- `static-vercel`: static frontends deployed through Vercel Git integration
+- `telegram-bot`: Telegram bots with service-style deployment
+- `flutter-app`: Flutter/Dart apps with mobile targets and optional web demo builds
+
 ## What Gets Installed
 
 - Durable documentation system under `docs_project/`

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -74,6 +74,8 @@ Install workflows:
 
 When a target repository already has a mature CI workflow, do not overwrite it. Keep the existing workflow, install the additional guard/review/security workflows, and set `.unicorn-hub/config.json` `requiredChecks` to the target's real CI job names plus the Unicorn guard and review jobs.
 
+Profiles can declare `excludeTemplates` to skip blueprint templates that conflict with the target stack. The `flutter-app` profile excludes the default Node `ci.yml`, so fresh Flutter targets are not handed a `baseline-checks` workflow that would never match their CI. `excludeTemplates` is enforced even under `--force`; the flag only refreshes templates the profile considers compatible.
+
 Set repository variables:
 
 - `AI_IMPLEMENTATION_AGENT`

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -16,6 +16,8 @@ The installing agent inspects the target repository and captures the minimum con
 
 If important context is unknown, the agent writes `[NEEDS CLARIFICATION]` into the relevant document instead of inventing details.
 
+Choose the closest profile before copying files. Profiles may provide stack-specific product paths, local commands, required checks, and dependency-update ecosystems. For example, a Flutter profile should preserve an existing Flutter CI workflow and use that workflow's job names as required checks instead of assuming the default Node `baseline-checks` job exists.
+
 ## Phase 1: Repository Memory
 
 Install:
@@ -69,6 +71,8 @@ Install workflows:
 - AI Command Policy
 - AI Review
 - OSV Scan
+
+When a target repository already has a mature CI workflow, do not overwrite it. Keep the existing workflow, install the additional guard/review/security workflows, and set `.unicorn-hub/config.json` `requiredChecks` to the target's real CI job names plus the Unicorn guard and review jobs.
 
 Set repository variables:
 

--- a/docs/github-ci-and-branch-protection.md
+++ b/docs/github-ci-and-branch-protection.md
@@ -4,11 +4,13 @@ GitHub is the control plane for pull requests, checks, and AI review routing.
 
 ## Required Workflows
 
-- `ci.yml`: runs repository baseline checks as `baseline-checks`
+- `ci.yml`: runs repository baseline checks as `baseline-checks`, unless a stack-specific profile preserves an existing target CI workflow
 - `pr-guard.yml`: enforces documentation and feature-memory coverage as `guard`
 - `ai-command-policy.yml`: validates trusted AI command comments
 - `ai-review.yml`: normalizes native review output into a required `AI Review` check
 - `osv-scan.yml`: scans dependencies for known vulnerabilities
+
+For existing repositories, `requiredChecks` comes from `.unicorn-hub/config.json`. Profiles that preserve a target CI workflow should list the target's current job names there, plus `guard` and `AI Review`.
 
 ## Fail-Closed Rules
 
@@ -33,6 +35,8 @@ require conversation resolution: true
 allow force pushes: false
 allow deletions: false
 ```
+
+If a profile preserves existing CI, replace `baseline-checks` with that repository's required job names before applying branch protection. For a Flutter app, that can be a set such as `Lint`, `Unit tests`, `Widget tests`, `Build Web`, and `Build Android APK`.
 
 Use `scripts/apply-branch-protection.mjs` from a trusted local checkout.
 

--- a/docs/local-preflight.md
+++ b/docs/local-preflight.md
@@ -21,6 +21,8 @@ It should run, at minimum:
 - tests
 - sanitizer for blueprint/template repositories
 
+Profiles may override the installed control-plane `preflight` script to call target-native checks after Unicorn gates. For example, a Flutter target can keep its existing `make check` and `make test` workflow while still running repository baseline and feature-memory validation first.
+
 ## Pre-Push Guard
 
 Optionally install a local hook or agent pre-tool hook that blocks `git push` when product paths changed without a complete feature-memory folder.

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -33,6 +33,8 @@ Dependabot should run weekly with cooldown:
 - minor: 7 days
 - patch: 3 days
 
+Profiles should include only ecosystems that match the target repository. JavaScript-oriented profiles use `npm`; Flutter profiles should use `pub`; all profiles can keep `github-actions` for workflow updates.
+
 ## GitHub Actions
 
 Third-party actions should be pinned by commit SHA with a trailing `# v<tag>` comment. Official `actions/*` may use pinned major versions or SHA pinning according to the target repository's policy.

--- a/profiles/flutter-app.json
+++ b/profiles/flutter-app.json
@@ -1,0 +1,64 @@
+{
+  "id": "flutter-app",
+  "description": "Flutter/Dart application with mobile targets and optional web demo builds.",
+  "docsDir": "docs_project",
+  "specsDir": "specs",
+  "productPaths": [
+    "lib/",
+    "test/",
+    "integration_test/",
+    "test_driver/",
+    "pubspec.yaml",
+    "pubspec.lock",
+    "analysis_options.yaml",
+    "l10n.yaml",
+    "android/",
+    "ios/",
+    "web/",
+    "macos/",
+    "linux/",
+    "windows/",
+    "docker/",
+    "script/",
+    "Makefile",
+    ".github/workflows/ci.yml"
+  ],
+  "packageManager": "pnpm",
+  "nodeVersion": "20",
+  "commands": {
+    "install": "make deps && make gen-l10n",
+    "lint": "make check",
+    "test": "make test",
+    "unitTest": "make test-unit",
+    "widgetTest": "make test-widget",
+    "buildWeb": "flutter build web --release",
+    "buildAndroid": "flutter build apk --release",
+    "preflight": "pnpm run check:repo && node scripts/check-feature-memory.mjs --worktree && make check && make test"
+  },
+  "packageScripts": {
+    "check:flutter": "make check && make test",
+    "preflight": "pnpm run check:repo && node scripts/check-feature-memory.mjs --worktree && pnpm run check:flutter"
+  },
+  "requiredChecks": [
+    "Lint",
+    "Unit tests",
+    "Widget tests",
+    "Build Web",
+    "Build Android APK",
+    "guard",
+    "AI Review"
+  ],
+  "dependabotUpdates": [
+    {
+      "packageEcosystem": "github-actions",
+      "directory": "/"
+    },
+    {
+      "packageEcosystem": "pub",
+      "directory": "/"
+    }
+  ],
+  "deploy": {
+    "type": "mobile-app-store-with-web-demo"
+  }
+}

--- a/profiles/flutter-app.json
+++ b/profiles/flutter-app.json
@@ -17,10 +17,9 @@
     "web/",
     "macos/",
     "linux/",
-    "windows/",
-    "docker/",
-    "script/",
-    "Makefile",
+    "windows/"
+  ],
+  "excludeTemplates": [
     ".github/workflows/ci.yml"
   ],
   "packageManager": "pnpm",
@@ -33,7 +32,7 @@
     "widgetTest": "make test-widget",
     "buildWeb": "flutter build web --release",
     "buildAndroid": "flutter build apk --release",
-    "preflight": "pnpm run check:repo && node scripts/check-feature-memory.mjs --worktree && make check && make test"
+    "preflight": "pnpm run preflight"
   },
   "packageScripts": {
     "check:flutter": "make check && make test",

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -28,7 +28,6 @@ const packageName = projectName
 const profile = readJson(profilePath);
 const force = Boolean(args.force);
 const dryRun = Boolean(args["dry-run"]);
-const installedPaths = new Set();
 
 const replacements = {
   PROJECT_NAME: projectName,
@@ -46,42 +45,45 @@ function dependabotLabel(ecosystem) {
 }
 
 function renderDependabot(updates) {
-  return [
-    "version: 2",
-    "updates:",
-    ...updates.flatMap((update) => {
-      const ecosystem = String(update["package-ecosystem"] || update.packageEcosystem || "");
-      const directory = String(update.directory || "/");
-      const interval = String(update.schedule?.interval || "weekly");
-      const day = String(update.schedule?.day || "monday");
-      const time = String(update.schedule?.time || "07:00");
-      const timezone = String(update.schedule?.timezone || "UTC");
-      const label = dependabotLabel(ecosystem);
+  const blocks = updates.map((update, index) => {
+    const ecosystem = String(update["package-ecosystem"] || update.packageEcosystem || "").trim();
+    if (!ecosystem) {
+      throw new Error(`dependabotUpdates entry ${index} is missing 'packageEcosystem'`);
+    }
+    const directory = String(update.directory || "/");
+    const interval = String(update.schedule?.interval || "weekly");
+    const time = String(update.schedule?.time || "07:00");
+    const timezone = String(update.schedule?.timezone || "UTC");
+    const label = dependabotLabel(ecosystem);
 
-      return [
-        `  - package-ecosystem: "${ecosystem}"`,
-        `    directory: "${directory}"`,
-        "    schedule:",
-        `      interval: "${interval}"`,
-        `      day: "${day}"`,
-        `      time: "${time}"`,
-        `      timezone: "${timezone}"`,
-        `    open-pull-requests-limit: ${Number(update.openPullRequestsLimit || update["open-pull-requests-limit"] || 5)}`,
-        "    labels:",
-        "      - \"dependencies\"",
-        `      - "${label}"`,
-        "    commit-message:",
-        `      prefix: "${String(update.commitMessage?.prefix || update["commit-message"]?.prefix || "chore")}"`,
-        "      include: \"scope\"",
-        "    cooldown:",
-        `      default-days: ${Number(update.cooldown?.defaultDays || update.cooldown?.["default-days"] || 7)}`,
-        `      semver-major-days: ${Number(update.cooldown?.semverMajorDays || update.cooldown?.["semver-major-days"] || 14)}`,
-        `      semver-minor-days: ${Number(update.cooldown?.semverMinorDays || update.cooldown?.["semver-minor-days"] || 7)}`,
-        `      semver-patch-days: ${Number(update.cooldown?.semverPatchDays || update.cooldown?.["semver-patch-days"] || 3)}`,
-        ""
-      ];
-    })
-  ].join("\n");
+    const lines = [
+      `  - package-ecosystem: "${ecosystem}"`,
+      `    directory: "${directory}"`,
+      "    schedule:",
+      `      interval: "${interval}"`
+    ];
+    if (interval === "weekly") {
+      lines.push(`      day: "${String(update.schedule?.day || "monday")}"`);
+    }
+    lines.push(
+      `      time: "${time}"`,
+      `      timezone: "${timezone}"`,
+      `    open-pull-requests-limit: ${Number(update.openPullRequestsLimit || update["open-pull-requests-limit"] || 5)}`,
+      "    labels:",
+      "      - \"dependencies\"",
+      `      - "${label}"`,
+      "    commit-message:",
+      `      prefix: "${String(update.commitMessage?.prefix || update["commit-message"]?.prefix || "chore")}"`,
+      "      include: \"scope\"",
+      "    cooldown:",
+      `      default-days: ${Number(update.cooldown?.defaultDays || update.cooldown?.["default-days"] || 7)}`,
+      `      semver-major-days: ${Number(update.cooldown?.semverMajorDays || update.cooldown?.["semver-major-days"] || 14)}`,
+      `      semver-minor-days: ${Number(update.cooldown?.semverMinorDays || update.cooldown?.["semver-minor-days"] || 7)}`,
+      `      semver-patch-days: ${Number(update.cooldown?.semverPatchDays || update.cooldown?.["semver-patch-days"] || 3)}`
+    );
+    return lines.join("\n");
+  });
+  return `version: 2\nupdates:\n${blocks.join("\n\n")}\n`;
 }
 
 function copyFileFromSource(sourceFile, targetFile, { template = true } = {}) {
@@ -98,12 +100,16 @@ function copyFileFromSource(sourceFile, targetFile, { template = true } = {}) {
   if (!dryRun) {
     mkdirSync(dirname(target), { recursive: true });
     writeFileSync(target, content);
-    installedPaths.add(targetFile);
   }
 }
 
+const excludeTemplates = new Set(profile.excludeTemplates || []);
 for (const rel of walkFiles(join(sourceRoot, "templates"))) {
   if (rel === ".unicorn-hub/config.json") continue;
+  if (excludeTemplates.has(rel)) {
+    planned.push({ action: "exclude", target: rel });
+    continue;
+  }
   copyFileFromSource(join(sourceRoot, "templates", rel), rel);
 }
 
@@ -146,14 +152,19 @@ if (!dryRun && (force || !existsSync(join(targetRoot, ".unicorn-hub/config.json"
   writeFileSync(join(targetRoot, ".unicorn-hub/config.json"), `${JSON.stringify(config, null, 2)}\n`);
 }
 
-if (!dryRun && profile.packageScripts && installedPaths.has("package.json")) {
+if (!dryRun && profile.packageScripts) {
   const packageJsonPath = join(targetRoot, "package.json");
-  const packageJson = readJson(packageJsonPath);
-  packageJson.scripts = {
-    ...(packageJson.scripts || {}),
-    ...profile.packageScripts
-  };
-  writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+  if (existsSync(packageJsonPath)) {
+    const packageJson = readJson(packageJsonPath);
+    packageJson.scripts = {
+      ...(packageJson.scripts || {}),
+      ...profile.packageScripts
+    };
+    writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    planned.push({ action: "scripts", target: "package.json" });
+  } else {
+    planned.push({ action: "warn", target: "package.json (missing; profile packageScripts not merged)" });
+  }
 }
 
 if (!dryRun && args["copy-profiles"]) {

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -28,6 +28,7 @@ const packageName = projectName
 const profile = readJson(profilePath);
 const force = Boolean(args.force);
 const dryRun = Boolean(args["dry-run"]);
+const installedPaths = new Set();
 
 const replacements = {
   PROJECT_NAME: projectName,
@@ -40,6 +41,49 @@ const replacements = {
 
 const planned = [];
 
+function dependabotLabel(ecosystem) {
+  return ecosystem === "github-actions" ? "github-actions" : ecosystem;
+}
+
+function renderDependabot(updates) {
+  return [
+    "version: 2",
+    "updates:",
+    ...updates.flatMap((update) => {
+      const ecosystem = String(update["package-ecosystem"] || update.packageEcosystem || "");
+      const directory = String(update.directory || "/");
+      const interval = String(update.schedule?.interval || "weekly");
+      const day = String(update.schedule?.day || "monday");
+      const time = String(update.schedule?.time || "07:00");
+      const timezone = String(update.schedule?.timezone || "UTC");
+      const label = dependabotLabel(ecosystem);
+
+      return [
+        `  - package-ecosystem: "${ecosystem}"`,
+        `    directory: "${directory}"`,
+        "    schedule:",
+        `      interval: "${interval}"`,
+        `      day: "${day}"`,
+        `      time: "${time}"`,
+        `      timezone: "${timezone}"`,
+        `    open-pull-requests-limit: ${Number(update.openPullRequestsLimit || update["open-pull-requests-limit"] || 5)}`,
+        "    labels:",
+        "      - \"dependencies\"",
+        `      - "${label}"`,
+        "    commit-message:",
+        `      prefix: "${String(update.commitMessage?.prefix || update["commit-message"]?.prefix || "chore")}"`,
+        "      include: \"scope\"",
+        "    cooldown:",
+        `      default-days: ${Number(update.cooldown?.defaultDays || update.cooldown?.["default-days"] || 7)}`,
+        `      semver-major-days: ${Number(update.cooldown?.semverMajorDays || update.cooldown?.["semver-major-days"] || 14)}`,
+        `      semver-minor-days: ${Number(update.cooldown?.semverMinorDays || update.cooldown?.["semver-minor-days"] || 7)}`,
+        `      semver-patch-days: ${Number(update.cooldown?.semverPatchDays || update.cooldown?.["semver-patch-days"] || 3)}`,
+        ""
+      ];
+    })
+  ].join("\n");
+}
+
 function copyFileFromSource(sourceFile, targetFile, { template = true } = {}) {
   const target = join(targetRoot, targetFile);
   if (existsSync(target) && !force) {
@@ -47,11 +91,14 @@ function copyFileFromSource(sourceFile, targetFile, { template = true } = {}) {
     return;
   }
   const raw = readFileSync(sourceFile, "utf8");
-  const content = template ? replacePlaceholders(raw, replacements) : raw;
+  const content = targetFile === ".github/dependabot.yml" && Array.isArray(profile.dependabotUpdates)
+    ? renderDependabot(profile.dependabotUpdates)
+    : template ? replacePlaceholders(raw, replacements) : raw;
   planned.push({ action: existsSync(target) ? "overwrite" : "create", target: targetFile });
   if (!dryRun) {
     mkdirSync(dirname(target), { recursive: true });
     writeFileSync(target, content);
+    installedPaths.add(targetFile);
   }
 }
 
@@ -89,13 +136,24 @@ const config = {
   defaultReviewAgent: "codex",
   trustedReviewLogins: [],
   trustedReviewLoginsByAgent: {},
-  profile: profile.id
+  profile: profile.id,
+  commands: profile.commands || {}
 };
 
 planned.push({ action: existsSync(join(targetRoot, ".unicorn-hub/config.json")) && !force ? "skip" : "create", target: ".unicorn-hub/config.json" });
 if (!dryRun && (force || !existsSync(join(targetRoot, ".unicorn-hub/config.json")))) {
   mkdirSync(join(targetRoot, ".unicorn-hub"), { recursive: true });
   writeFileSync(join(targetRoot, ".unicorn-hub/config.json"), `${JSON.stringify(config, null, 2)}\n`);
+}
+
+if (!dryRun && profile.packageScripts && installedPaths.has("package.json")) {
+  const packageJsonPath = join(targetRoot, "package.json");
+  const packageJson = readJson(packageJsonPath);
+  packageJson.scripts = {
+    ...(packageJson.scripts || {}),
+    ...profile.packageScripts
+  };
+  writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 }
 
 if (!dryRun && args["copy-profiles"]) {

--- a/scripts/shared.mjs
+++ b/scripts/shared.mjs
@@ -61,6 +61,7 @@ export function walkFiles(root, options = {}) {
     ".claude",
     ".codex",
     ".omc",
+    ".omx",
     "node_modules",
     "dist",
     "coverage",

--- a/specs/005-flutter-profile-ci-compat/plan.md
+++ b/specs/005-flutter-profile-ci-compat/plan.md
@@ -1,0 +1,49 @@
+# Plan: Flutter Profile CI Compatibility
+
+## Summary
+
+Add a stack-specific Flutter profile and make bootstrap honor profile-defined local scripts and Dependabot ecosystems. Preserve existing target CI by default, then document that branch protection should use the target's real job names instead of assuming the default Node `baseline-checks` job exists.
+
+## Technical Context
+
+- runtime: Node.js 20 for Unicorn scripts; target runtime is Flutter/Dart.
+- dependencies: no new runtime dependencies.
+- product paths: `profiles/`, `scripts/`, `docs/`, `tests/`, and `specs/`.
+- data changes: new profile JSON and generated target config fields.
+
+## Scope Boundaries
+
+- in scope: `profiles/flutter-app.json`, bootstrap profile handling, docs, tests, and feature memory.
+- out of scope: real app migration, real target CI replacement, and branch protection API changes.
+
+## Constitution Check
+
+- Spec-first: this feature folder records goal, scope, acceptance criteria, negative scenarios, and verification evidence.
+- Testable boundaries: synthetic bootstrap test covers the compatibility contract.
+- PR-only: changes are prepared on a feature branch for pull request review.
+- Simplicity: profile fields are plain JSON and bootstrap keeps default template behavior when fields are absent.
+- Deployability: no deployment platform assumptions are introduced.
+
+## Complexity Tracking
+
+Bootstrap gains two profile-aware extension points: `packageScripts` for installed control-plane `package.json`, and `dependabotUpdates` for profile-matched Dependabot ecosystems. Both are opt-in and preserve existing behavior for profiles that do not set them. Repository walking also learns `.omx/` as local runtime state, matching existing `.omc/` handling.
+
+## Verification
+
+| Acceptance criterion | Evidence |
+| --- | --- |
+| AC-001 | `tests/bootstrap.test.mjs` preserves a synthetic existing `.github/workflows/ci.yml`. |
+| AC-002 | `tests/bootstrap.test.mjs` asserts Flutter product paths in `.unicorn-hub/config.json`. |
+| AC-003 | `tests/bootstrap.test.mjs` asserts Flutter required checks include `Build Android APK` and exclude `baseline-checks`. |
+| AC-004 | `tests/bootstrap.test.mjs` asserts generated Dependabot includes `github-actions` and `pub`, not `npm`. |
+| AC-005 | `pnpm run preflight` passed locally with sanitizer, baseline, workflow sync, syntax, and 19 tests green. |
+| AC-006 | `tests/sanitizer.test.mjs` asserts `.omx/` runtime state is ignored. |
+
+Negative scenario evidence:
+
+- Existing generic bootstrap test continues to cover default package/template behavior.
+- Synthetic Flutter bootstrap test verifies target CI is skipped without `--force`.
+
+## Risks
+
+- Some Flutter targets may not use Make. Mitigation: commands are visible in generated config and package scripts, so teams can adjust during bootstrap review.

--- a/specs/005-flutter-profile-ci-compat/plan.md
+++ b/specs/005-flutter-profile-ci-compat/plan.md
@@ -26,7 +26,13 @@ Add a stack-specific Flutter profile and make bootstrap honor profile-defined lo
 
 ## Complexity Tracking
 
-Bootstrap gains two profile-aware extension points: `packageScripts` for installed control-plane `package.json`, and `dependabotUpdates` for profile-matched Dependabot ecosystems. Both are opt-in and preserve existing behavior for profiles that do not set them. Repository walking also learns `.omx/` as local runtime state, matching existing `.omc/` handling.
+Bootstrap gains three profile-aware extension points:
+
+- `packageScripts` for the installed control-plane `package.json`, merged whether bootstrap freshly created the file or it already existed.
+- `dependabotUpdates` for profile-matched Dependabot ecosystems with required `packageEcosystem` and weekly-only `day` emission.
+- `excludeTemplates` for templates that the profile considers incompatible (e.g., the default Node CI workflow for Flutter), enforced regardless of `--force`.
+
+All three are opt-in and preserve existing behavior for profiles that do not set them. Repository walking also learns `.omx/` as local runtime state, matching existing `.omc/` handling.
 
 ## Verification
 
@@ -34,10 +40,13 @@ Bootstrap gains two profile-aware extension points: `packageScripts` for install
 | --- | --- |
 | AC-001 | `tests/bootstrap.test.mjs` preserves a synthetic existing `.github/workflows/ci.yml`. |
 | AC-002 | `tests/bootstrap.test.mjs` asserts Flutter product paths in `.unicorn-hub/config.json`. |
-| AC-003 | `tests/bootstrap.test.mjs` asserts Flutter required checks include `Build Android APK` and exclude `baseline-checks`. |
+| AC-003 | `tests/bootstrap.test.mjs` asserts Flutter required checks include `Build Android APK`, `guard`, `AI Review`, and exclude `baseline-checks`. |
 | AC-004 | `tests/bootstrap.test.mjs` asserts generated Dependabot includes `github-actions` and `pub`, not `npm`. |
-| AC-005 | `pnpm run preflight` passed locally with sanitizer, baseline, workflow sync, syntax, and 19 tests green. |
+| AC-005 | `pnpm run preflight` passes locally with sanitizer, baseline, workflow sync, syntax, and the updated test suite. |
 | AC-006 | `tests/sanitizer.test.mjs` asserts `.omx/` runtime state is ignored. |
+| AC-007 | `tests/bootstrap.test.mjs` "fresh Flutter target" case asserts no `ci.yml` is installed and Unicorn guard / AI review / OSV workflows still land. |
+| AC-008 | `tests/bootstrap.test.mjs` "--force still preserves Flutter ci.yml" case asserts `excludeTemplates` overrides `--force`. |
+| AC-009 | `tests/bootstrap.test.mjs` "merges profile packageScripts into a pre-existing package.json" case asserts user scripts survive and profile scripts are merged in. |
 
 Negative scenario evidence:
 

--- a/specs/005-flutter-profile-ci-compat/spec.md
+++ b/specs/005-flutter-profile-ci-compat/spec.md
@@ -1,0 +1,59 @@
+# Spec: Flutter Profile CI Compatibility
+
+## Goal
+
+Add a portable Flutter/Dart profile that can bootstrap existing mobile app repositories without overwriting their established CI workflows.
+
+## Scope
+
+In scope:
+
+- Add a `flutter-app` profile with Flutter product paths, commands, required checks, and dependency-update ecosystems.
+- Keep existing target `.github/workflows/ci.yml` files untouched during bootstrap unless `--force` is explicitly used.
+- Generate target control-plane scripts that can run Unicorn gates and Flutter-native checks together.
+- Keep local runtime state directories out of portability/sanitizer scans.
+- Document how stack-specific profiles preserve target CI job names.
+- Cover the bootstrap behavior with synthetic tests.
+
+Out of scope:
+
+- Adding a real Flutter application example.
+- Changing branch protection defaults for existing profiles.
+- Replacing target repository CI workflows.
+
+## User Stories
+
+### User Story 1
+
+As an agent installing Unicorn Hub into an existing Flutter app, I want a Flutter-specific profile, so that feature-memory gates and AI review controls can be added without breaking the app's current CI/CD.
+
+## Acceptance Criteria
+
+1. Given a synthetic target repository with an existing Flutter CI workflow, when bootstrap runs with `--profile flutter-app`, then the existing CI workflow remains unchanged.
+2. Given a bootstrapped Flutter target, when `.unicorn-hub/config.json` is inspected, then product paths include Flutter source, tests, platform folders, and CI files.
+3. Given a bootstrapped Flutter target, when required checks are inspected, then they include Flutter CI job names plus `guard` and `AI Review`, and do not require the default Node `baseline-checks` job.
+4. Given a bootstrapped Flutter target, when Dependabot config is inspected, then it includes `github-actions` and `pub` ecosystems.
+5. Given this blueprint PR, when preflight runs, then sanitizer, baseline, workflow sync, syntax, and tests pass.
+6. Given local runtime state exists under `.omx/`, when sanitizer runs, then that state is ignored like other local agent runtime directories.
+
+## Negative Scenarios
+
+1. Given a non-Flutter profile, when bootstrap runs, then existing behavior remains compatible and the default template package scripts are preserved unless that profile explicitly overrides them.
+2. Given target CI is already present, when bootstrap runs without `--force`, then the target CI file is skipped rather than overwritten.
+
+## Requirements
+
+- FR-001: The profile must stay generic and avoid product-specific repository names, paths, or private context.
+- FR-002: Bootstrap must support profile-specific `packageScripts` without mutating an existing target `package.json` that was skipped.
+- FR-003: Bootstrap must support profile-specific Dependabot ecosystems.
+- FR-004: Documentation must explain how stack-specific profiles use existing CI job names.
+- FR-005: Local OMX runtime state must be ignored by repository file walks and git.
+
+## Success Criteria
+
+- SC-001: The synthetic Flutter bootstrap test proves CI preservation and generated configuration.
+- SC-002: `pnpm run preflight` passes locally before publication.
+
+## Assumptions
+
+- Target Flutter repositories commonly expose `make check` and `make test`, but teams can edit generated scripts after bootstrap if their commands differ.

--- a/specs/005-flutter-profile-ci-compat/spec.md
+++ b/specs/005-flutter-profile-ci-compat/spec.md
@@ -9,11 +9,11 @@ Add a portable Flutter/Dart profile that can bootstrap existing mobile app repos
 In scope:
 
 - Add a `flutter-app` profile with Flutter product paths, commands, required checks, and dependency-update ecosystems.
-- Keep existing target `.github/workflows/ci.yml` files untouched during bootstrap unless `--force` is explicitly used.
+- Add a profile-level `excludeTemplates` field so stack-specific profiles can opt out of incompatible blueprint templates regardless of `--force`.
 - Generate target control-plane scripts that can run Unicorn gates and Flutter-native checks together.
 - Keep local runtime state directories out of portability/sanitizer scans.
 - Document how stack-specific profiles preserve target CI job names.
-- Cover the bootstrap behavior with synthetic tests.
+- Cover the bootstrap behavior with synthetic tests, including fresh targets, `--force` re-runs, and pre-existing target `package.json`.
 
 Out of scope:
 
@@ -30,24 +30,28 @@ As an agent installing Unicorn Hub into an existing Flutter app, I want a Flutte
 ## Acceptance Criteria
 
 1. Given a synthetic target repository with an existing Flutter CI workflow, when bootstrap runs with `--profile flutter-app`, then the existing CI workflow remains unchanged.
-2. Given a bootstrapped Flutter target, when `.unicorn-hub/config.json` is inspected, then product paths include Flutter source, tests, platform folders, and CI files.
+2. Given a bootstrapped Flutter target, when `.unicorn-hub/config.json` is inspected, then product paths include Flutter source, tests, and platform folders.
 3. Given a bootstrapped Flutter target, when required checks are inspected, then they include Flutter CI job names plus `guard` and `AI Review`, and do not require the default Node `baseline-checks` job.
 4. Given a bootstrapped Flutter target, when Dependabot config is inspected, then it includes `github-actions` and `pub` ecosystems.
 5. Given this blueprint PR, when preflight runs, then sanitizer, baseline, workflow sync, syntax, and tests pass.
 6. Given local runtime state exists under `.omx/`, when sanitizer runs, then that state is ignored like other local agent runtime directories.
+7. Given a fresh Flutter target with no pre-existing `.github/workflows/ci.yml`, when bootstrap runs with `--profile flutter-app`, then the default Node `baseline-checks` workflow is not installed; the target keeps full ownership of its CI workflow file while still receiving Unicorn guard, AI review, and OSV workflows.
+8. Given a Flutter target with an existing `.github/workflows/ci.yml`, when bootstrap runs with `--force` and `--profile flutter-app`, then the target CI file is still preserved because the profile excludes that template.
+9. Given a target with a pre-existing `package.json`, when bootstrap runs with a profile that defines `packageScripts`, then those scripts are merged into the existing file, profile entries override colliding keys, and unrelated user-defined scripts are preserved.
 
 ## Negative Scenarios
 
 1. Given a non-Flutter profile, when bootstrap runs, then existing behavior remains compatible and the default template package scripts are preserved unless that profile explicitly overrides them.
-2. Given target CI is already present, when bootstrap runs without `--force`, then the target CI file is skipped rather than overwritten.
+2. Given target CI is already present, when bootstrap runs without `--force` for any profile, then the target CI file is skipped rather than overwritten.
 
 ## Requirements
 
 - FR-001: The profile must stay generic and avoid product-specific repository names, paths, or private context.
-- FR-002: Bootstrap must support profile-specific `packageScripts` without mutating an existing target `package.json` that was skipped.
-- FR-003: Bootstrap must support profile-specific Dependabot ecosystems.
+- FR-002: Bootstrap must merge profile-specific `packageScripts` into the target `package.json`, whether the file was freshly installed by bootstrap or pre-existed in the target, while preserving unrelated user-defined scripts.
+- FR-003: Bootstrap must support profile-specific Dependabot ecosystems and validate that each entry declares an ecosystem.
 - FR-004: Documentation must explain how stack-specific profiles use existing CI job names.
 - FR-005: Local OMX runtime state must be ignored by repository file walks and git.
+- FR-006: Profiles may declare an `excludeTemplates` list. Templates listed there must never be installed into the target, including under `--force`.
 
 ## Success Criteria
 

--- a/specs/005-flutter-profile-ci-compat/tasks.md
+++ b/specs/005-flutter-profile-ci-compat/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: Flutter Profile CI Compatibility
+
+## Setup
+
+- [x] T001 Confirm active feature folder and branch.
+- [x] T002 Run baseline orientation before editing.
+
+## Implementation
+
+- [x] T003 Add a neutral `flutter-app` profile.
+- [x] T004 Make bootstrap apply profile-specific package scripts only when it installs `package.json`.
+- [x] T005 Make bootstrap render profile-specific Dependabot ecosystems.
+- [x] T006 Document stack-specific CI preservation and required-check mapping.
+- [x] T007 Add synthetic bootstrap coverage for Flutter CI compatibility.
+- [x] T008 Ignore local OMX runtime state in file walks and git.
+
+## Verification
+
+- [x] T009 Run local preflight.
+- [x] T010 Update verification evidence after checks complete.
+
+## Process Memory
+
+### Dead Ends
+
+- None yet.
+
+### Decisions
+
+- Preserve existing target CI by default and map required checks through profile config instead of replacing mature workflows.
+- Keep the profile generic: no private repository names, real product details, or owner-specific paths.
+- Treat `.omx/` as local runtime state like `.omc/`, so sanitizer remains useful on machines with OMX installed.
+
+### Known Issues
+
+- Flutter projects without Make need a small generated-script edit during bootstrap review.

--- a/specs/005-flutter-profile-ci-compat/tasks.md
+++ b/specs/005-flutter-profile-ci-compat/tasks.md
@@ -8,11 +8,15 @@
 ## Implementation
 
 - [x] T003 Add a neutral `flutter-app` profile.
-- [x] T004 Make bootstrap apply profile-specific package scripts only when it installs `package.json`.
-- [x] T005 Make bootstrap render profile-specific Dependabot ecosystems.
+- [x] T004 Make bootstrap merge profile-specific `packageScripts` into the target `package.json` whether the file was freshly installed or pre-existed.
+- [x] T005 Make bootstrap render profile-specific Dependabot ecosystems with ecosystem validation and weekly-only `day` emission.
 - [x] T006 Document stack-specific CI preservation and required-check mapping.
 - [x] T007 Add synthetic bootstrap coverage for Flutter CI compatibility.
 - [x] T008 Ignore local OMX runtime state in file walks and git.
+- [x] T011 Add `excludeTemplates` profile field so stack-specific profiles can opt out of incompatible blueprint templates regardless of `--force`.
+- [x] T012 Wire `flutter-app` to exclude the default Node `ci.yml` template so fresh Flutter targets do not receive `baseline-checks`.
+- [x] T013 Trim `flutter-app` `productPaths` to standard Flutter folders and collapse `commands.preflight` to the canonical `pnpm run preflight` to remove duplication with `packageScripts.preflight`.
+- [x] T014 Extend `tests/bootstrap.test.mjs` with fresh-target, `--force`-preserve, and pre-existing-`package.json` scenarios.
 
 ## Verification
 
@@ -23,14 +27,18 @@
 
 ### Dead Ends
 
-- None yet.
+- Initial implementation gated `packageScripts` merging on `installedPaths.has("package.json")`. That silently dropped profile scripts when the target already had a `package.json`, leaving the generated `preflight` referencing nonexistent commands. Replaced with an `existsSync` check at merge time and removed the dead `installedPaths` set.
+- Initial implementation relied on the generic "skip if exists" rule to preserve target CI. That broke for fresh Flutter targets, which received the default Node `ci.yml`, and for `--force` re-runs, which clobbered an existing Flutter CI. Replaced with profile-level `excludeTemplates`, enforced regardless of `--force`.
 
 ### Decisions
 
 - Preserve existing target CI by default and map required checks through profile config instead of replacing mature workflows.
-- Keep the profile generic: no private repository names, real product details, or owner-specific paths.
+- Keep the profile generic: no private repository names, real product details, or owner-specific paths. `productPaths` were trimmed to standard Flutter folders only.
 - Treat `.omx/` as local runtime state like `.omc/`, so sanitizer remains useful on machines with OMX installed.
+- `excludeTemplates` always wins over `--force`. `--force` is for refreshing Unicorn scaffolding, not for clobbering target stacks the profile declared incompatible.
+- `commands.preflight` in the profile points at `pnpm run preflight`; `packageScripts.preflight` is the single source of the actual command chain.
 
 ### Known Issues
 
-- Flutter projects without Make need a small generated-script edit during bootstrap review.
+- Flutter projects without Make still need a small generated-script edit during bootstrap review.
+- Other profiles (`python-service`, `next-app`, `static-vercel`, `telegram-bot`) do not yet declare `dependabotUpdates`, so they inherit the static `npm`-only Dependabot template. Tracked as a follow-up; out of scope for this PR.

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -104,14 +104,110 @@ test("bootstrap preserves Flutter CI and installs Flutter profile controls", () 
   assert.deepEqual(config.productPaths.slice(0, 4), ["lib/", "test/", "integration_test/", "test_driver/"]);
   assert.equal(config.requiredChecks.includes("baseline-checks"), false);
   assert.equal(config.requiredChecks.includes("Build Android APK"), true);
-  assert.equal(config.commands.preflight.includes("make check"), true);
+  assert.equal(config.requiredChecks.includes("guard"), true);
+  assert.equal(config.requiredChecks.includes("AI Review"), true);
+  assert.equal(config.commands.lint, "make check");
+  assert.equal(config.commands.preflight, "pnpm run preflight");
 
   const packageJson = JSON.parse(readFileSync(join(target, "package.json"), "utf8"));
-  assert.equal(packageJson.scripts.preflight.includes("pnpm run check:flutter"), true);
+  assert.match(packageJson.scripts.preflight, /pnpm run check:flutter/);
   assert.equal(packageJson.scripts["check:flutter"], "make check && make test");
 
   const dependabot = readFileSync(join(target, ".github/dependabot.yml"), "utf8");
   assert.match(dependabot, /package-ecosystem: "github-actions"/);
   assert.match(dependabot, /package-ecosystem: "pub"/);
   assert.doesNotMatch(dependabot, /package-ecosystem: "npm"/);
+});
+
+test("bootstrap into a fresh Flutter target excludes the default Node CI workflow", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-flutter-fresh-"));
+  writeFileSync(join(target, "pubspec.yaml"), "name: synthetic_flutter_app\n");
+
+  run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "flutter-app",
+    "--project-name",
+    "Fresh Flutter App"
+  ]);
+
+  assert.equal(
+    existsSync(join(target, ".github/workflows/ci.yml")),
+    false,
+    "default Node ci.yml must not be installed for the flutter-app profile"
+  );
+  assert.equal(existsSync(join(target, ".github/workflows/pr-guard.yml")), true);
+  assert.equal(existsSync(join(target, ".github/workflows/ai-review.yml")), true);
+  assert.equal(existsSync(join(target, ".github/workflows/osv-scan.yml")), true);
+
+  const config = JSON.parse(readFileSync(join(target, ".unicorn-hub/config.json"), "utf8"));
+  assert.equal(config.requiredChecks.includes("baseline-checks"), false);
+});
+
+test("bootstrap with --force still preserves Flutter ci.yml via excludeTemplates", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-flutter-force-"));
+  mkdirSync(join(target, ".github/workflows"), { recursive: true });
+  writeFileSync(join(target, ".github/workflows/ci.yml"), "name: Existing Flutter CI\n");
+  writeFileSync(join(target, "pubspec.yaml"), "name: synthetic_flutter_app\n");
+
+  run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "flutter-app",
+    "--project-name",
+    "Force Flutter App",
+    "--force"
+  ]);
+
+  assert.equal(
+    readFileSync(join(target, ".github/workflows/ci.yml"), "utf8"),
+    "name: Existing Flutter CI\n",
+    "excludeTemplates must protect target ci.yml even with --force"
+  );
+});
+
+test("bootstrap merges profile packageScripts into a pre-existing package.json", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-flutter-existing-pkg-"));
+  writeFileSync(join(target, "pubspec.yaml"), "name: synthetic_flutter_app\n");
+  writeFileSync(
+    join(target, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "existing-app",
+        private: true,
+        scripts: {
+          custom: "echo custom",
+          preflight: "echo old-preflight"
+        }
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "flutter-app",
+    "--project-name",
+    "Existing Pkg Flutter"
+  ]);
+
+  const packageJson = JSON.parse(readFileSync(join(target, "package.json"), "utf8"));
+  assert.equal(packageJson.name, "existing-app", "user package.json identity must be preserved");
+  assert.equal(packageJson.scripts.custom, "echo custom", "user-defined scripts must be preserved");
+  assert.equal(packageJson.scripts["check:flutter"], "make check && make test");
+  assert.match(packageJson.scripts.preflight, /pnpm run check:flutter/, "profile preflight must override the user one");
 });

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -76,4 +76,42 @@ test("bootstrapped target passes baseline check", () => {
 
   const output = run(["scripts/check-repo-baseline.mjs", "--target", target]);
   assert.match(output, /Repository baseline check passed/);
+});
+
+test("bootstrap preserves Flutter CI and installs Flutter profile controls", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-flutter-"));
+  mkdirSync(join(target, ".github/workflows"), { recursive: true });
+  writeFileSync(join(target, ".github/workflows/ci.yml"), "name: Existing Flutter CI\n");
+  writeFileSync(join(target, "pubspec.yaml"), "name: synthetic_flutter_app\n");
+  writeFileSync(join(target, "Makefile"), "check:\n\tflutter analyze lib test\n");
+
+  run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "flutter-app",
+    "--project-name",
+    "Synthetic Flutter App"
+  ]);
+
+  assert.equal(readFileSync(join(target, ".github/workflows/ci.yml"), "utf8"), "name: Existing Flutter CI\n");
+
+  const config = JSON.parse(readFileSync(join(target, ".unicorn-hub/config.json"), "utf8"));
+  assert.equal(config.profile, "flutter-app");
+  assert.deepEqual(config.productPaths.slice(0, 4), ["lib/", "test/", "integration_test/", "test_driver/"]);
+  assert.equal(config.requiredChecks.includes("baseline-checks"), false);
+  assert.equal(config.requiredChecks.includes("Build Android APK"), true);
+  assert.equal(config.commands.preflight.includes("make check"), true);
+
+  const packageJson = JSON.parse(readFileSync(join(target, "package.json"), "utf8"));
+  assert.equal(packageJson.scripts.preflight.includes("pnpm run check:flutter"), true);
+  assert.equal(packageJson.scripts["check:flutter"], "make check && make test");
+
+  const dependabot = readFileSync(join(target, ".github/dependabot.yml"), "utf8");
+  assert.match(dependabot, /package-ecosystem: "github-actions"/);
+  assert.match(dependabot, /package-ecosystem: "pub"/);
+  assert.doesNotMatch(dependabot, /package-ecosystem: "npm"/);
 });

--- a/tests/sanitizer.test.mjs
+++ b/tests/sanitizer.test.mjs
@@ -51,3 +51,18 @@ test("sanitizer rejects common personal path formats", () => {
     });
   }
 });
+
+test("sanitizer ignores local OMX runtime state", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-sanitize-omx-"));
+  mkdirSync(join(target, ".omx/state"), { recursive: true });
+  writeFileSync(join(target, ".omx/state/session.json"), JSON.stringify({
+    cwd: `/${"Users"}/synthetic/project`
+  }));
+
+  const output = execFileSync("node", ["scripts/sanitize-blueprint.mjs", "--target", target], {
+    cwd: root,
+    encoding: "utf8"
+  });
+
+  assert.match(output, /Sanitizer check passed/);
+});


### PR DESCRIPTION
## Summary

- Add a portable `flutter-app` profile for Flutter/Dart repositories with mobile targets and optional web demo builds.
- Make bootstrap honor profile-specific package scripts and Dependabot ecosystems while preserving existing target CI workflows unless `--force` is used.
- Document stack-specific CI preservation, add feature memory, and ignore local `.omx/` runtime state in repo file walks.

## Why

Existing Flutter apps often already have mature CI jobs for lint, unit tests, widget tests, web builds, and Android builds. The blueprint should install Unicorn guard/review controls around that CI instead of replacing it with the default Node `baseline-checks` workflow.

## Validation

- `pnpm run preflight`
- Synthetic bootstrap check against a Flutter-like target with an existing `.github/workflows/ci.yml`
- Local bootstrap smoke against a real Flutter-shaped target archive: existing CI was skipped, Flutter product paths/checks were generated, and Dependabot used `github-actions` + `pub`

## Notes

- This is a ready PR from the `cucumberfalse` fork into `kiaquila/unicorn-hub`.
- The profile stays generic and does not include private repository names or target-product details.
