### PR TITLE
docs: make Unicorn Hub onboarding executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,31 @@ Use this prompt in the target repository when you want to install the blueprint:
 
 ```text
 Use the Unicorn Hub repository at https://github.com/kiaquila/unicorn-hub as
-the process blueprint. If you need a local copy, clone or open it first.
-Install the portable multi-agent development blueprint into the current
-repository, choose the closest project profile, adapt placeholders, run local
-verification, and prepare a pull request. After bootstrap, follow CREATE-DOCS.md
-to build docs_project before creating the first feature spec. Do not copy
+the process blueprint. If you do not already have a local copy, clone it
+first (the bootstrap script needs a filesystem path). Install the portable
+multi-agent development blueprint into the current repository, choose the
+closest project profile, adapt placeholders, run local verification, and
+prepare a pull request. After bootstrap, follow CREATE-DOCS.md to build
+docs_project before creating the first feature spec. Do not copy
 project-specific examples or secrets.
 ```
 
-Then run, from the target repository, using your local Unicorn Hub path:
+If you do not already have a local clone, get one first:
 
 ```bash
-node /path/to/unicorn-hub/scripts/bootstrap-repo.mjs \
-  --source /path/to/unicorn-hub \
+git clone https://github.com/kiaquila/unicorn-hub /tmp/unicorn-hub
+```
+
+Then run, from the target repository, pointing `--source` at the local Unicorn Hub path:
+
+```bash
+node /tmp/unicorn-hub/scripts/bootstrap-repo.mjs \
+  --source /tmp/unicorn-hub \
   --profile next-app \
   --project-name "Your Project"
 ```
 
-If the agent says it cannot find Unicorn Hub, pass the GitHub URL above or the local `--source` path explicitly.
+`--source` only accepts a local filesystem path; it does not resolve a Git URL. If the agent says it cannot find Unicorn Hub, share the GitHub URL above so the agent can clone it, then re-run the command with the resulting local path.
 
 Profiles live in [`profiles/`](./profiles). If no profile fits, use `generic` values in `.unicorn-hub/config.json` after bootstrapping.
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,24 @@ This repository is meant to be copied by agents into a new project. It contains 
 
 ## Quickstart For Agents
 
-Use this prompt in the target repository:
+Unicorn Hub can be used in two ways:
+
+- Analyze and adopt: ask an agent to inspect this blueprint and recommend which parts fit an existing repository.
+- Install: bootstrap the portable workflow files into a target repository, then create or refresh project docs before product-code work.
+
+Use this prompt in the target repository when you want to install the blueprint:
 
 ```text
-Use Unicorn Hub as the source of truth. Install the portable multi-agent
-development blueprint into the current repository. Choose the closest project
-profile, adapt placeholders, run local verification, and prepare a pull request.
-Do not copy project-specific examples or secrets.
+Use the Unicorn Hub repository at https://github.com/kiaquila/unicorn-hub as
+the process blueprint. If you need a local copy, clone or open it first.
+Install the portable multi-agent development blueprint into the current
+repository, choose the closest project profile, adapt placeholders, run local
+verification, and prepare a pull request. After bootstrap, follow CREATE-DOCS.md
+to build docs_project before creating the first feature spec. Do not copy
+project-specific examples or secrets.
 ```
 
-Then run, from the target repository:
+Then run, from the target repository, using your local Unicorn Hub path:
 
 ```bash
 node /path/to/unicorn-hub/scripts/bootstrap-repo.mjs \
@@ -23,6 +31,8 @@ node /path/to/unicorn-hub/scripts/bootstrap-repo.mjs \
   --profile next-app \
   --project-name "Your Project"
 ```
+
+If the agent says it cannot find Unicorn Hub, pass the GitHub URL above or the local `--source` path explicitly.
 
 Profiles live in [`profiles/`](./profiles). If no profile fits, use `generic` values in `.unicorn-hub/config.json` after bootstrapping.
 
@@ -53,6 +63,19 @@ Current profiles include:
 4. Run local preflight before every push.
 5. Let CI, PR guard, and AI review fail closed.
 6. Merge only after required checks are green and blocking review findings are resolved.
+
+## After Bootstrap
+
+For a new or under-documented target repository, ask the agent to run the installed documentation interview before implementation:
+
+```text
+Read CREATE-DOCS.md and ai-docs-guide.md in this repository.
+Interview me in small batches and write durable project docs under docs_project/.
+When docs are sufficient, create the first specs/<feature-id>/spec.md, plan.md,
+and tasks.md. Do not implement product code yet.
+```
+
+If project docs already exist, use the same protocol to review and refresh them instead of duplicating them.
 
 ## Repository Map
 

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -27,7 +27,7 @@ Install:
 - `docs_project/`
 - `.unicorn-hub/config.json`
 
-The target repository must have a reading route before product code changes begin.
+The target repository must have a reading route before product code changes begin. For a new or under-documented target, the installed `CREATE-DOCS.md` protocol is the first setup path: interview the user, write durable docs under `docs_project/`, and only then move into feature memory.
 
 ## Phase 2: Spec-Kit Style Feature Memory
 
@@ -102,12 +102,13 @@ After the workflows exist on the default branch, apply branch protection:
 
 ## Phase 6: First Feature PR
 
-The first feature validates the whole system:
+The first feature validates the whole system after project docs are present or refreshed:
 
-1. create a feature worktree
-2. write `spec.md`, `plan.md`, `tasks.md`
-3. implement only scoped changes
-4. run preflight
-5. publish PR
-6. trigger AI review from a trusted human account
-7. merge only after all gates are green
+1. follow `CREATE-DOCS.md` if `docs_project/` is empty, stale, or still contains placeholders
+2. create a feature worktree
+3. write `spec.md`, `plan.md`, `tasks.md`
+4. implement only scoped changes
+5. run preflight
+6. publish PR
+7. trigger AI review from a trusted human account
+8. merge only after all gates are green

--- a/docs/documentation-system.md
+++ b/docs/documentation-system.md
@@ -40,7 +40,7 @@ The SENAR layer gives those files a shared contract:
 
 ## Interview Protocol
 
-The generic interview lives in [`templates/CREATE-DOCS.md`](../templates/CREATE-DOCS.md). It asks a small batch of questions at a time and writes documentation after each phase.
+The generic interview lives in [`templates/CREATE-DOCS.md`](../templates/CREATE-DOCS.md). It is the first setup protocol for new or under-documented target repositories: ask a small batch of questions at a time, summarize what was understood, write documentation after each phase, and keep implementation paused until the durable docs and first feature spec are ready.
 
 The key phases are:
 
@@ -51,6 +51,8 @@ The key phases are:
 5. screens or interaction maps
 6. agent rules
 7. final consistency validation
+
+Use the installed `ai-docs-guide.md` as supporting context for structure, file size, and validation expectations.
 
 ## Context Hygiene
 

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -200,7 +200,7 @@ if (dryRun) {
   if (wroteSomething) {
     console.log("1. Review placeholders in AGENTS.md, CLAUDE.md, docs_project/, and .unicorn-hub/config.json.");
   } else {
-    console.log("1. No new files were written; existing AGENTS.md, CLAUDE.md, docs_project/, and .unicorn-hub/config.json already match the blueprint.");
+    console.log("1. No new files were written. Existing AGENTS.md, CLAUDE.md, docs_project/, and .unicorn-hub/config.json were preserved as-is (their contents were not compared to the blueprint); review them for stale placeholders or re-run with --force to refresh from the blueprint.");
   }
   console.log("2. For a new or under-documented project, ask an agent to follow CREATE-DOCS.md before product code.");
   console.log("3. Create the first specs/<feature-id>/{spec.md,plan.md,tasks.md}.");

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -190,4 +190,8 @@ for (const item of planned) {
 
 console.log("");
 console.log(`Installed Unicorn Hub blueprint profile '${profileId}' into ${relative(process.cwd(), targetRoot) || "."}`);
-console.log("Next: review placeholders, run the project preflight, then open a PR.");
+console.log("Next:");
+console.log("1. Review placeholders in AGENTS.md, CLAUDE.md, docs_project/, and .unicorn-hub/config.json.");
+console.log("2. For a new or under-documented project, ask an agent to follow CREATE-DOCS.md before product code.");
+console.log("3. Create the first specs/<feature-id>/{spec.md,plan.md,tasks.md}.");
+console.log("4. Run the project preflight, then open a PR.");

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -189,9 +189,20 @@ for (const item of planned) {
 }
 
 console.log("");
-console.log(`Installed Unicorn Hub blueprint profile '${profileId}' into ${relative(process.cwd(), targetRoot) || "."}`);
-console.log("Next:");
-console.log("1. Review placeholders in AGENTS.md, CLAUDE.md, docs_project/, and .unicorn-hub/config.json.");
-console.log("2. For a new or under-documented project, ask an agent to follow CREATE-DOCS.md before product code.");
-console.log("3. Create the first specs/<feature-id>/{spec.md,plan.md,tasks.md}.");
-console.log("4. Run the project preflight, then open a PR.");
+const targetLabel = relative(process.cwd(), targetRoot) || ".";
+const wroteSomething = planned.some(item => item.action === "create" || item.action === "overwrite" || item.action === "scripts");
+
+if (dryRun) {
+  console.log(`Dry run for Unicorn Hub blueprint profile '${profileId}' against ${targetLabel}. Nothing was written. Re-run without --dry-run to apply.`);
+} else {
+  console.log(`Installed Unicorn Hub blueprint profile '${profileId}' into ${targetLabel}`);
+  console.log("Next:");
+  if (wroteSomething) {
+    console.log("1. Review placeholders in AGENTS.md, CLAUDE.md, docs_project/, and .unicorn-hub/config.json.");
+  } else {
+    console.log("1. No new files were written; existing AGENTS.md, CLAUDE.md, docs_project/, and .unicorn-hub/config.json already match the blueprint.");
+  }
+  console.log("2. For a new or under-documented project, ask an agent to follow CREATE-DOCS.md before product code.");
+  console.log("3. Create the first specs/<feature-id>/{spec.md,plan.md,tasks.md}.");
+  console.log("4. Run the project preflight, then open a PR.");
+}

--- a/specs/006-onboarding-activation-flow/plan.md
+++ b/specs/006-onboarding-activation-flow/plan.md
@@ -1,0 +1,50 @@
+# Plan: Onboarding Activation Flow
+
+## Summary
+
+Close the gap between "install the blueprint" and "start building with it" by making the public quickstart self-contained, surfacing the documentation interview, and teaching bootstrap to print concrete next steps.
+
+## Technical Context
+
+- runtime: Node.js 20 for bootstrap and validation scripts.
+- dependencies: no new runtime dependencies.
+- product paths: `README.md`, `docs/`, `templates/`, `scripts/bootstrap-repo.mjs`, `tests/bootstrap.test.mjs`, and `specs/`.
+- data changes: documentation and test-only assertions; no schema or workflow changes.
+
+## Scope Boundaries
+
+- in scope: onboarding copy, installed template guidance, bootstrap terminal output, and synthetic test coverage.
+- out of scope: changes to PR guard behavior, AI review policy, branch protection settings, or spec template structure.
+
+## Constitution Check
+
+- Spec-first: this feature folder records goal, scope, acceptance criteria, negative scenarios, verification evidence, and process memory before product edits.
+- Testable boundaries: bootstrap output and installed template guidance are covered by `tests/bootstrap.test.mjs`.
+- PR-only: changes are prepared on a feature branch for pull request review.
+- Simplicity: wording changes reuse existing files and the existing `CREATE-DOCS.md` protocol instead of adding a new onboarding system.
+- Portability: all examples stay generic and avoid secrets, private paths, and source-project residue.
+
+## Complexity Tracking
+
+This change adds no new abstraction. The only behavior change is replacing the final bootstrap message with a short ordered next-step block. That keeps the runtime path simple while making the installed experience less ambiguous.
+
+## Verification
+
+| Acceptance criterion | Evidence |
+| --- | --- |
+| AC-001 | Root `README.md` quickstart names `https://github.com/kiaquila/unicorn-hub` and tells agents to clone or open it if needed. |
+| AC-002 | Root `README.md` keeps explicit `--source /path/to/unicorn-hub` bootstrap usage. |
+| AC-003 | `tests/bootstrap.test.mjs` asserts bootstrap output names `CREATE-DOCS.md`, `docs_project`, `specs/<feature-id>`, and `preflight`. |
+| AC-004 | `tests/bootstrap.test.mjs` asserts installed `README.md`, `AGENTS.md`, and `CLAUDE.md` include first-setup guidance. |
+| AC-005 | Existing Flutter installed-doc assertions continue to check `.unicorn-hub/config.json` guidance for required checks. |
+| AC-006 | `pnpm run preflight` passes locally before publication. |
+
+Negative scenario evidence:
+
+- README and installed docs phrase the docs step as create or refresh/review, so documented projects are not told to duplicate their docs.
+- Local `--source` examples remain available when GitHub access is unavailable.
+
+## Risks
+
+- More README text could make the quickstart feel heavy. Mitigation: split by use case and keep each prompt short.
+- Agents may still skip first-setup docs if users ask for immediate implementation. Mitigation: installed `AGENTS.md` and `CLAUDE.md` make placeholder docs a pre-code signal.

--- a/specs/006-onboarding-activation-flow/plan.md
+++ b/specs/006-onboarding-activation-flow/plan.md
@@ -32,12 +32,11 @@ This change adds no new abstraction. The only behavior change is replacing the f
 
 | Acceptance criterion | Evidence |
 | --- | --- |
-| AC-001 | Root `README.md` quickstart names `https://github.com/kiaquila/unicorn-hub` and tells agents to clone or open it if needed. |
+| AC-001 | Root `README.md` quickstart names `https://github.com/kiaquila/unicorn-hub`, includes a `git clone` example, and clarifies that `--source` only accepts a local filesystem path. |
 | AC-002 | Root `README.md` keeps explicit `--source /path/to/unicorn-hub` bootstrap usage. |
-| AC-003 | `tests/bootstrap.test.mjs` asserts bootstrap output names `CREATE-DOCS.md`, `docs_project`, `specs/<feature-id>`, and `preflight`. |
-| AC-004 | `tests/bootstrap.test.mjs` asserts installed `README.md`, `AGENTS.md`, and `CLAUDE.md` include first-setup guidance. |
-| AC-005 | Existing Flutter installed-doc assertions continue to check `.unicorn-hub/config.json` guidance for required checks. |
-| AC-006 | `pnpm run preflight` passes locally before publication. |
+| AC-003 | `tests/bootstrap.test.mjs` parses the `Next:` block from bootstrap output and asserts the four numbered steps name `CREATE-DOCS.md`, `docs_project`, `specs/<feature-id>`, and `preflight`. A dry-run test confirms bootstrap announces a dry run instead, and an idempotent re-run test confirms the message switches to "no new files were written". |
+| AC-004 | `tests/bootstrap.test.mjs` asserts installed `README.md`, `AGENTS.md`, `CLAUDE.md`, and `docs_project/README.md` include first-setup guidance, and `tests/sanitizer.test.mjs` asserts the canonical hub owner name does not appear in `templates/`. |
+| AC-005 | `pnpm run preflight` passes locally before publication. |
 
 Negative scenario evidence:
 

--- a/specs/006-onboarding-activation-flow/spec.md
+++ b/specs/006-onboarding-activation-flow/spec.md
@@ -1,0 +1,68 @@
+# Spec: Onboarding Activation Flow
+
+## Goal
+
+Make Unicorn Hub's public quickstart and installed repository guidance executable for agents and humans, from finding the blueprint through the first project docs and first feature spec.
+
+## Scope
+
+In scope:
+
+- Clarify the source discovery path in the root `README.md`, including the canonical GitHub URL and local `--source` usage.
+- Add an explicit post-bootstrap path for empty or under-documented target repositories.
+- Surface `CREATE-DOCS.md` as the first project-documentation protocol before product-code work.
+- Update installed templates so bootstrapped repositories tell agents what to do before the first feature.
+- Update bootstrap output to print actionable next steps.
+- Add synthetic tests for the new bootstrap output and installed guidance.
+
+Out of scope:
+
+- Changing the spec-kit architecture or file layout.
+- Changing GitHub workflow semantics, branch protection, or AI review policy.
+- Adding product-specific examples, private repository references, or real deployment details.
+
+## User Stories
+
+### User Story 1
+
+As a user trying Unicorn Hub from GitHub, I want the quickstart prompt to name the blueprint source explicitly, so that my agent does not fail before bootstrap by trying to infer or search for the repository.
+
+### User Story 2
+
+As a user bootstrapping an empty repository, I want clear next steps after installation, so that I know to document the project and create the first feature spec before asking an agent to implement code.
+
+### User Story 3
+
+As an agent working inside a newly bootstrapped target repository, I want installed guidance to detect placeholder project docs, so that I ask for product context instead of inventing implementation details.
+
+## Acceptance Criteria
+
+1. Given the root `README.md`, when a user copies the quickstart prompt, then the prompt includes the canonical Unicorn Hub GitHub URL and tells the agent to clone or open the blueprint if needed.
+2. Given the root `README.md`, when a user has already cloned Unicorn Hub locally, then the bootstrap command still shows explicit `--source /path/to/unicorn-hub` usage.
+3. Given bootstrap finishes successfully, when the terminal output is inspected, then it names `CREATE-DOCS.md`, `docs_project`, `specs/<feature-id>`, and the project preflight as next steps.
+4. Given a target repository is bootstrapped, when installed `README.md`, `AGENTS.md`, or `CLAUDE.md` are inspected, then they include first-setup guidance for running the documentation interview before product code.
+5. Given installed docs are generated for stack-specific profiles, when those docs describe required checks, then they still point at `.unicorn-hub/config.json` instead of hard-coding profile-sensitive status contexts.
+6. Given this blueprint PR, when `pnpm run preflight` runs, then sanitizer, baseline, workflow sync, syntax, and tests pass.
+
+## Negative Scenarios
+
+1. Given a target repository already has mature project docs, when bootstrap guidance is read, then the user is told to refresh or review docs rather than duplicate them blindly.
+2. Given the agent cannot access GitHub, when following the quickstart, then the docs still offer the local `--source` path as the supported path.
+
+## Requirements
+
+- FR-001: Public quickstart guidance must be self-contained enough for an agent that has no prior knowledge of Unicorn Hub.
+- FR-002: Post-bootstrap guidance must separate project documentation, feature memory, and implementation into distinct ordered steps.
+- FR-003: Installed templates must direct agents to `CREATE-DOCS.md` and `ai-docs-guide.md` for first setup.
+- FR-004: Bootstrap output must print concrete next actions, not only a generic "review placeholders" message.
+- FR-005: All new examples must remain neutral and synthetic.
+
+## Success Criteria
+
+- SC-001: A user can paste the root quickstart prompt into an agent and the agent has enough information to locate Unicorn Hub.
+- SC-002: A bootstrapped empty target gives the user a clear route from placeholders to docs, first spec, and implementation.
+
+## Assumptions
+
+- The canonical public repository URL is `https://github.com/kiaquila/unicorn-hub`.
+- `CREATE-DOCS.md` is the supported first-setup documentation interview for new or under-documented projects.

--- a/specs/006-onboarding-activation-flow/spec.md
+++ b/specs/006-onboarding-activation-flow/spec.md
@@ -41,8 +41,7 @@ As an agent working inside a newly bootstrapped target repository, I want instal
 2. Given the root `README.md`, when a user has already cloned Unicorn Hub locally, then the bootstrap command still shows explicit `--source /path/to/unicorn-hub` usage.
 3. Given bootstrap finishes successfully, when the terminal output is inspected, then it names `CREATE-DOCS.md`, `docs_project`, `specs/<feature-id>`, and the project preflight as next steps.
 4. Given a target repository is bootstrapped, when installed `README.md`, `AGENTS.md`, or `CLAUDE.md` are inspected, then they include first-setup guidance for running the documentation interview before product code.
-5. Given installed docs are generated for stack-specific profiles, when those docs describe required checks, then they still point at `.unicorn-hub/config.json` instead of hard-coding profile-sensitive status contexts.
-6. Given this blueprint PR, when `pnpm run preflight` runs, then sanitizer, baseline, workflow sync, syntax, and tests pass.
+5. Given this blueprint PR, when `pnpm run preflight` runs, then sanitizer, baseline, workflow sync, syntax, and tests pass.
 
 ## Negative Scenarios
 

--- a/specs/006-onboarding-activation-flow/tasks.md
+++ b/specs/006-onboarding-activation-flow/tasks.md
@@ -16,8 +16,8 @@
 ## Verification
 
 - [x] T008 Run focused tests.
-- [ ] T009 Run local preflight.
-- [ ] T010 Update verification evidence after checks complete.
+- [x] T009 Run local preflight.
+- [x] T010 Update verification evidence after checks complete.
 
 ## Process Memory
 
@@ -30,6 +30,7 @@
 - Keep this as one PR with separate commits for feature memory, public docs, installed docs, and behavior/tests.
 - Reuse the existing `CREATE-DOCS.md` protocol instead of introducing a second onboarding script or document.
 - Keep the PR documentation-only plus bootstrap-output behavior; no workflow or branch-protection semantics change.
+- Local `pnpm run preflight` passed with baseline, workflow sync, syntax, sanitizer, and 26 tests.
 
 ### Known Issues
 

--- a/specs/006-onboarding-activation-flow/tasks.md
+++ b/specs/006-onboarding-activation-flow/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: Onboarding Activation Flow
+
+## Setup
+
+- [x] T001 Confirm GitHub state, local branch state, and open PR baseline.
+- [x] T002 Create the feature folder and document the intended scope.
+
+## Implementation
+
+- [ ] T003 Update the root `README.md` with explicit source discovery, install, and post-bootstrap flows.
+- [ ] T004 Update blueprint docs to surface `CREATE-DOCS.md` as the first setup path.
+- [ ] T005 Update installed templates with first-setup guidance for empty or under-documented repositories.
+- [ ] T006 Update `scripts/bootstrap-repo.mjs` final output with concrete next steps.
+- [ ] T007 Add bootstrap tests for the new output and installed guidance.
+
+## Verification
+
+- [ ] T008 Run focused tests.
+- [ ] T009 Run local preflight.
+- [ ] T010 Update verification evidence after checks complete.
+
+## Process Memory
+
+### Dead Ends
+
+- None yet.
+
+### Decisions
+
+- Keep this as one PR with separate commits for feature memory, public docs, installed docs, and behavior/tests.
+- Reuse the existing `CREATE-DOCS.md` protocol instead of introducing a second onboarding script or document.
+- Keep the PR documentation-only plus bootstrap-output behavior; no workflow or branch-protection semantics change.
+
+### Known Issues
+
+- Native AI review still depends on a trusted human `@codex review` comment after PR creation, matching the current repository review contract.

--- a/specs/006-onboarding-activation-flow/tasks.md
+++ b/specs/006-onboarding-activation-flow/tasks.md
@@ -11,11 +11,11 @@
 - [x] T004 Update blueprint docs to surface `CREATE-DOCS.md` as the first setup path.
 - [x] T005 Update installed templates with first-setup guidance for empty or under-documented repositories.
 - [x] T006 Update `scripts/bootstrap-repo.mjs` final output with concrete next steps.
-- [ ] T007 Add bootstrap tests for the new output and installed guidance.
+- [x] T007 Add bootstrap tests for the new output and installed guidance.
 
 ## Verification
 
-- [ ] T008 Run focused tests.
+- [x] T008 Run focused tests.
 - [ ] T009 Run local preflight.
 - [ ] T010 Update verification evidence after checks complete.
 

--- a/specs/006-onboarding-activation-flow/tasks.md
+++ b/specs/006-onboarding-activation-flow/tasks.md
@@ -31,6 +31,7 @@
 - Reuse the existing `CREATE-DOCS.md` protocol instead of introducing a second onboarding script or document.
 - Keep the PR documentation-only plus bootstrap-output behavior; no workflow or branch-protection semantics change.
 - Bootstrap output branches on `--dry-run` and on whether anything was actually written, so a dry run or idempotent re-run no longer prints a misleading "Review placeholders" line.
+- The idempotent-re-run message states explicitly that existing files were preserved and not compared to the blueprint, and points users at `--force` to refresh, instead of claiming the targets "already match the blueprint" (which the script cannot verify).
 - `--source` is documented as a local filesystem path only; the README provides an explicit `git clone` step rather than implying URL support that the script does not have.
 - Local `pnpm run preflight` passed with baseline, workflow sync, syntax, sanitizer, and tests.
 

--- a/specs/006-onboarding-activation-flow/tasks.md
+++ b/specs/006-onboarding-activation-flow/tasks.md
@@ -30,8 +30,10 @@
 - Keep this as one PR with separate commits for feature memory, public docs, installed docs, and behavior/tests.
 - Reuse the existing `CREATE-DOCS.md` protocol instead of introducing a second onboarding script or document.
 - Keep the PR documentation-only plus bootstrap-output behavior; no workflow or branch-protection semantics change.
-- Local `pnpm run preflight` passed with baseline, workflow sync, syntax, sanitizer, and 26 tests.
+- Bootstrap output branches on `--dry-run` and on whether anything was actually written, so a dry run or idempotent re-run no longer prints a misleading "Review placeholders" line.
+- `--source` is documented as a local filesystem path only; the README provides an explicit `git clone` step rather than implying URL support that the script does not have.
+- Local `pnpm run preflight` passed with baseline, workflow sync, syntax, sanitizer, and tests.
 
 ### Known Issues
 
-- Native AI review still depends on a trusted human `@codex review` comment after PR creation, matching the current repository review contract.
+- None.

--- a/specs/006-onboarding-activation-flow/tasks.md
+++ b/specs/006-onboarding-activation-flow/tasks.md
@@ -9,8 +9,8 @@
 
 - [x] T003 Update the root `README.md` with explicit source discovery, install, and post-bootstrap flows.
 - [x] T004 Update blueprint docs to surface `CREATE-DOCS.md` as the first setup path.
-- [ ] T005 Update installed templates with first-setup guidance for empty or under-documented repositories.
-- [ ] T006 Update `scripts/bootstrap-repo.mjs` final output with concrete next steps.
+- [x] T005 Update installed templates with first-setup guidance for empty or under-documented repositories.
+- [x] T006 Update `scripts/bootstrap-repo.mjs` final output with concrete next steps.
 - [ ] T007 Add bootstrap tests for the new output and installed guidance.
 
 ## Verification

--- a/specs/006-onboarding-activation-flow/tasks.md
+++ b/specs/006-onboarding-activation-flow/tasks.md
@@ -7,8 +7,8 @@
 
 ## Implementation
 
-- [ ] T003 Update the root `README.md` with explicit source discovery, install, and post-bootstrap flows.
-- [ ] T004 Update blueprint docs to surface `CREATE-DOCS.md` as the first setup path.
+- [x] T003 Update the root `README.md` with explicit source discovery, install, and post-bootstrap flows.
+- [x] T004 Update blueprint docs to surface `CREATE-DOCS.md` as the first setup path.
 - [ ] T005 Update installed templates with first-setup guidance for empty or under-documented repositories.
 - [ ] T006 Update `scripts/bootstrap-repo.mjs` final output with concrete next steps.
 - [ ] T007 Add bootstrap tests for the new output and installed guidance.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -23,6 +23,15 @@ Before implementation work, read in this order:
 7. active `specs/<feature-id>/tasks.md`
 8. relevant source files
 
+If `docs_project/project-idea.md`, stack docs, or `AGENTS.md` still contain placeholders, run the first setup documentation interview before implementation:
+
+```text
+Read CREATE-DOCS.md and ai-docs-guide.md.
+Interview me in small batches and write durable project docs under docs_project/.
+When docs are sufficient, create the first specs/<feature-id>/spec.md, plan.md,
+and tasks.md. Do not implement product code yet.
+```
+
 ## Agent Roles
 
 ### Orchestrator

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -25,6 +25,17 @@ Claude Code is the default implementation agent unless repository policy says ot
 - Keep commit subjects short, conventional, and focused.
 - Do not add abstractions for single-use logic without a current need documented in `plan.md`.
 
+## First Setup
+
+If project docs are missing, stale, or still contain placeholders, pause implementation and run the documentation interview first:
+
+```text
+Read CREATE-DOCS.md and ai-docs-guide.md.
+Interview me in small batches and write durable project docs under docs_project/.
+When docs are sufficient, create the first specs/<feature-id>/spec.md, plan.md,
+and tasks.md. Do not implement product code yet.
+```
+
 ## Review Focus
 
 When asked to review, prioritize:

--- a/templates/README.md
+++ b/templates/README.md
@@ -14,6 +14,19 @@ This repository uses a portable multi-agent development workflow:
 - local preflight before push
 - GitHub CI, PR Guard, and AI Review gates
 
+## First Setup After Bootstrap
+
+If this repository is new or `docs_project/` still contains placeholders, start with the documentation interview before product code:
+
+```text
+Read CREATE-DOCS.md and ai-docs-guide.md.
+Interview me in small batches and write durable project docs under docs_project/.
+When docs are sufficient, create the first specs/<feature-id>/spec.md, plan.md,
+and tasks.md. Do not implement product code yet.
+```
+
+If project docs already exist, use the same protocol to review and refresh them.
+
 ## Local Commands
 
 ```bash

--- a/templates/docs_project/README.md
+++ b/templates/docs_project/README.md
@@ -2,6 +2,10 @@
 
 This folder stores durable project context for agents and humans.
 
+## First Setup
+
+For a new or under-documented repository, start with `CREATE-DOCS.md` and use `ai-docs-guide.md` as supporting structure. The agent should interview the user in small batches, write these docs, then create the first `specs/<feature-id>/` folder before product-code work.
+
 ## Read Order
 
 1. `project-idea.md`

--- a/templates/docs_project/README.md
+++ b/templates/docs_project/README.md
@@ -4,7 +4,7 @@ This folder stores durable project context for agents and humans.
 
 ## First Setup
 
-For a new or under-documented repository, start with `CREATE-DOCS.md` and use `ai-docs-guide.md` as supporting structure. The agent should interview the user in small batches, write these docs, then create the first `specs/<feature-id>/` folder before product-code work.
+For a new or under-documented repository, start with the repository-root [`CREATE-DOCS.md`](../CREATE-DOCS.md) and use [`ai-docs-guide.md`](../ai-docs-guide.md) as supporting structure (both live at the repo root, not inside `docs_project/`). The agent should interview the user in small batches, write these docs, then create the first `specs/<feature-id>/` folder before product-code work.
 
 ## Read Order
 

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -18,7 +18,7 @@ function run(args, cwd = root) {
 test("bootstrap installs generic blueprint into a synthetic target", () => {
   const target = mkdtempSync(join(tmpdir(), "unicorn-bootstrap-"));
 
-  run([
+  const output = run([
     "scripts/bootstrap-repo.mjs",
     "--source",
     root,
@@ -29,6 +29,11 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
     "--project-name",
     "Synthetic App"
   ]);
+
+  assert.match(output, /CREATE-DOCS\.md/);
+  assert.match(output, /docs_project/);
+  assert.match(output, /specs\/<feature-id>/);
+  assert.match(output, /preflight/);
 
   for (const path of [
     "AGENTS.md",
@@ -47,6 +52,20 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
   const agents = readFileSync(join(target, "AGENTS.md"), "utf8");
   assert.match(agents, /Synthetic App/);
   assert.doesNotMatch(agents, /<PROJECT_NAME>/);
+  assert.match(agents, /first setup documentation interview/i);
+  assert.match(agents, /CREATE-DOCS\.md/);
+
+  const readme = readFileSync(join(target, "README.md"), "utf8");
+  assert.match(readme, /First Setup After Bootstrap/);
+  assert.match(readme, /CREATE-DOCS\.md/);
+
+  const claude = readFileSync(join(target, "CLAUDE.md"), "utf8");
+  assert.match(claude, /## First Setup/);
+  assert.match(claude, /CREATE-DOCS\.md/);
+
+  const docsReadme = readFileSync(join(target, "docs_project/README.md"), "utf8");
+  assert.match(docsReadme, /## First Setup/);
+  assert.match(docsReadme, /specs\/<feature-id>/);
 
   const config = JSON.parse(readFileSync(join(target, ".unicorn-hub/config.json"), "utf8"));
   assert.equal(config.profile, "generic");

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -130,7 +130,9 @@ test("bootstrap idempotent re-run reports nothing new to review", () => {
   ]);
 
   const nextStepsBlock = output.split("\nNext:\n")[1] ?? "";
-  assert.match(nextStepsBlock, /^1\. No new files were written/m);
+  assert.match(nextStepsBlock, /^1\. No new files were written\. Existing/m);
+  assert.match(nextStepsBlock, /not compared to the blueprint/);
+  assert.match(nextStepsBlock, /--force/);
 });
 
 test("bootstrapped target passes baseline check", () => {

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -30,10 +30,12 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
     "Synthetic App"
   ]);
 
-  assert.match(output, /CREATE-DOCS\.md/);
-  assert.match(output, /docs_project/);
-  assert.match(output, /specs\/<feature-id>/);
-  assert.match(output, /preflight/);
+  const nextStepsBlock = output.split("\nNext:\n")[1] ?? "";
+  assert.notEqual(nextStepsBlock, "", "bootstrap output must contain a 'Next:' block");
+  assert.match(nextStepsBlock, /^1\. Review placeholders.*AGENTS\.md.*CLAUDE\.md.*docs_project\/.*\.unicorn-hub\/config\.json/m);
+  assert.match(nextStepsBlock, /^2\. .*CREATE-DOCS\.md/m);
+  assert.match(nextStepsBlock, /^3\. Create the first specs\/<feature-id>/m);
+  assert.match(nextStepsBlock, /^4\. Run the project preflight/m);
 
   for (const path of [
     "AGENTS.md",
@@ -76,6 +78,59 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
 
   const prTemplate = readFileSync(join(target, ".github/pull_request_template.md"), "utf8");
   assert.match(prTemplate, /SENAR Done Gate/);
+});
+
+test("bootstrap --dry-run announces a dry run instead of next steps", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-bootstrap-dry-"));
+
+  const output = run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Synthetic Dry",
+    "--dry-run"
+  ]);
+
+  assert.match(output, /Dry run for Unicorn Hub blueprint profile 'generic'/);
+  assert.match(output, /Re-run without --dry-run to apply\./);
+  assert.doesNotMatch(output, /\nNext:\n/);
+  assert.equal(existsSync(join(target, "AGENTS.md")), false, "dry run must not write files");
+});
+
+test("bootstrap idempotent re-run reports nothing new to review", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-bootstrap-rerun-"));
+
+  run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Synthetic Rerun"
+  ]);
+
+  const output = run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Synthetic Rerun"
+  ]);
+
+  const nextStepsBlock = output.split("\nNext:\n")[1] ?? "";
+  assert.match(nextStepsBlock, /^1\. No new files were written/m);
 });
 
 test("bootstrapped target passes baseline check", () => {

--- a/tests/sanitizer.test.mjs
+++ b/tests/sanitizer.test.mjs
@@ -1,9 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
+import { walkFiles } from "../scripts/shared.mjs";
 
 const root = resolve(".");
 
@@ -50,6 +51,22 @@ test("sanitizer rejects common personal path formats", () => {
       });
     });
   }
+});
+
+test("installed templates do not leak the canonical hub owner name", () => {
+  const templatesRoot = join(root, "templates");
+  const offending = [];
+  for (const rel of walkFiles(templatesRoot)) {
+    const content = readFileSync(join(templatesRoot, rel), "utf8");
+    if (/kiaquila/i.test(content) || /kiaquila/i.test(rel)) {
+      offending.push(rel);
+    }
+  }
+  assert.deepEqual(
+    offending,
+    [],
+    `templates/ must not embed the canonical hub owner; found in: ${offending.join(", ")}`
+  );
 });
 
 test("sanitizer ignores local OMX runtime state", () => {


### PR DESCRIPTION
## Summary

This PR closes the onboarding gap found in the chapppp trial flow: agents could read the quickstart but still fail to locate Unicorn Hub or know what to do after bootstrap.

It adds an explicit source-discovery path, makes the empty-project flow point through CREATE-DOCS.md, and updates bootstrap output plus installed docs so the next steps are visible inside target repositories.

## Changes

- Add feature memory for the onboarding activation flow.
- Make the root quickstart name https://github.com/kiaquila/unicorn-hub and keep explicit local --source usage.
- Add post-bootstrap guidance for docs_project and the first specs/<feature-id> folder.
- Update installed README, AGENTS.md, CLAUDE.md, and docs_project/README.md with first-setup guidance.
- Print actionable bootstrap next steps and cover them with synthetic tests.

## Verification

- pnpm test -- tests/bootstrap.test.mjs
- pnpm run preflight
