### PR TITLE
docs: use @ syntax for CLAUDE.md doc references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@ Claude Code may implement blueprint changes in this repository.
 
 ## Read Before Coding
 
-1. `AGENTS.md`
-2. `README.md`
-3. `docs/bootstrap-flow.md`
-4. `docs/portability-and-sanitization.md`
+1. @AGENTS.md
+2. @README.md
+3. @docs/bootstrap-flow.md
+4. @docs/portability-and-sanitization.md
 5. relevant scripts/templates/tests
 
 ## Operating Rules

--- a/specs/009-claude-md-at-syntax/plan.md
+++ b/specs/009-claude-md-at-syntax/plan.md
@@ -1,0 +1,33 @@
+# Plan: Claude MD At-Syntax References
+
+## Summary
+
+This is a documentation-contract refinement. The root and template
+`CLAUDE.md` files already list the right documents to read before coding. The
+implementation keeps that order and changes only the reference syntax for the
+canonical paths that Claude Code should treat as explicit file mentions.
+
+## Implementation Outline
+
+- Update root `CLAUDE.md` read-order entries from inline-code paths to
+  `@path` references.
+- Update `templates/CLAUDE.md` read-order entries for installed target
+  repositories in the same style.
+- Leave role definitions, review policy, and workflow instructions unchanged.
+- Add this feature-memory folder so PR Guard can verify the documentation
+  change has an explicit goal, plan, and task record.
+
+## Verification
+
+- Review the diff to confirm only the intended `CLAUDE.md` reference syntax
+  changed.
+- Run `pnpm run preflight` to cover sanitizer, baseline, and test checks.
+- Confirm PR Guard no longer reports a missing feature-memory folder.
+
+## Decisions and Constraints
+
+- Do not add a new abstraction or script; this is a text-only compatibility
+  tweak.
+- Keep examples synthetic and generic, matching Unicorn Hub's portability
+  contract.
+- Preserve existing filenames and directories.

--- a/specs/009-claude-md-at-syntax/spec.md
+++ b/specs/009-claude-md-at-syntax/spec.md
@@ -1,0 +1,48 @@
+# Spec: Claude MD At-Syntax References
+
+## Goal
+
+Update the root and template `CLAUDE.md` read-order references so Claude Code
+can recognize important repository documents as explicit `@` file references
+while preserving the existing read order and portable blueprint wording.
+
+## Scope
+
+In scope:
+
+- root `CLAUDE.md` read-before-coding references
+- `templates/CLAUDE.md` read-before-coding references copied into target
+  repositories
+- feature-memory evidence for the documentation-only change
+
+Out of scope:
+
+- changing agent roles, supported review backends, or merge policy
+- changing bootstrap behavior
+- adding project-specific examples or private repository references
+
+## Acceptance Criteria
+
+- AC-001: Root `CLAUDE.md` uses `@` file references for the canonical local
+  files listed before coding.
+- AC-002: `templates/CLAUDE.md` uses `@` file references for canonical files
+  that should be auto-load friendly in target repositories.
+- AC-003: The existing read order is preserved; only the reference syntax
+  changes.
+- AC-004: The blueprint remains generic and sanitizer-safe.
+- AC-005: Local preflight passes before the PR is considered ready to merge.
+
+## Negative Scenarios
+
+- The change must not introduce real user paths, private repository URLs,
+  deployment identifiers, or source-project product details.
+- The change must not rename existing files or move documentation locations.
+- The change must not require downstream repositories to adopt a new directory
+  layout beyond the already documented Unicorn Hub template layout.
+
+## Assumptions
+
+- Claude Code recognizes `@path` references as stronger file-reference cues
+  than backtick-wrapped plain paths in `CLAUDE.md`.
+- Markdown readability remains acceptable without wrapping the `@path`
+  references in inline code spans.

--- a/specs/009-claude-md-at-syntax/tasks.md
+++ b/specs/009-claude-md-at-syntax/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Claude MD At-Syntax References
+
+## Implementation
+
+- [x] T001 Update root `CLAUDE.md` read-order paths to `@` references.
+- [x] T002 Update `templates/CLAUDE.md` read-order paths to `@` references.
+- [x] T003 Add feature-memory spec, plan, and tasks files for PR Guard.
+- [x] T004 Run `pnpm run preflight`.
+- [ ] T005 Verify PR checks after pushing the branch.
+
+## Process Memory
+
+- The change intentionally preserves the existing read order and surrounding
+  policy text. The only intended behavior is making important documentation
+  paths easier for Claude Code to detect as file references.
+- No downstream bootstrap behavior changes are needed because target
+  repositories already receive `templates/CLAUDE.md`.
+- `pnpm run preflight` passed locally on 2026-05-14 before publishing the
+  feature-memory fix.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -4,9 +4,9 @@ Claude Code is the default implementation agent unless repository policy says ot
 
 ## Read Before Coding
 
-1. `.specify/memory/constitution.md`
-2. `AGENTS.md`
-3. `docs_project/README.md`
+1. @.specify/memory/constitution.md
+2. @AGENTS.md
+3. @docs_project/README.md
 4. active `specs/<feature-id>/spec.md`
 5. active `specs/<feature-id>/plan.md`
 6. active `specs/<feature-id>/tasks.md`


### PR DESCRIPTION
## Summary
- Convert "Read Before Coding" path references to `@` syntax in both root CLAUDE.md and templates/CLAUDE.md
- `@path` makes Claude Code auto-load file content at session start

## Why
Per Anthropic recommendation. Updating the blueprint template propagates the convention to all future projects bootstrapped from Unicorn Hub.

## Scope
- `CLAUDE.md`: items 1–4 of Read Before Coding (AGENTS.md, README.md, bootstrap-flow.md, portability-and-sanitization.md)
- `templates/CLAUDE.md`: items 1–3 (constitution, AGENTS.md, docs_project/README.md); spec placeholders remain as backticks.

## Test plan
- [ ] Required checks pass
- [ ] No broken paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)