### PR TITLE
[codex] Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Unicorn Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Add a root MIT `LICENSE` file for the Unicorn Hub repository.
- Use standard MIT license text based on the `kiaquila/pallete-maker` reference.
- Keep the copyright line generic for the portable blueprint: `Unicorn Hub contributors`.

## Validation

- `node scripts/preflight.mjs` passed locally, including feature-memory gate, repository baseline check, workflow sync check, syntax check, sanitizer, and 37 Node tests.

## Review

- Addressed Codex review feedback by replacing the copied individual copyright holder with a neutral blueprint-safe contributor attribution.

## Notes

`pnpm` is not available in this local shell, so I ran the underlying project preflight script directly with Node.