### PR TITLE
Vendor governance envelope out of consumer Linguist stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Current profiles include:
 - Local orchestration scripts for worktrees, PR publishing, feature-memory gates, context budget checks, AI review gates, and branch protection
 - GitHub Actions workflows for CI, PR guard, trusted AI review routing, and OSV scanning
 - Supply-chain defaults: pnpm `minimumReleaseAge`, Dependabot cooldown, pinned package manager, lockfile-oriented installs
+- A `.gitattributes` block that marks the installed governance envelope (`scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, so the blueprint's Node scaffolding does not skew the target repo's GitHub language bar. Bootstrap appends this block idempotently and never overwrites an existing consumer `.gitattributes`; product code keeps its language stats.
 
 ## Canonical Workflow
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Current profiles include:
 - Local orchestration scripts for worktrees, PR publishing, feature-memory gates, context budget checks, AI review gates, and branch protection
 - GitHub Actions workflows for CI, PR guard, trusted AI review routing, and OSV scanning
 - Supply-chain defaults: pnpm `minimumReleaseAge`, Dependabot cooldown, pinned package manager, lockfile-oriented installs
-- A `.gitattributes` block that marks the installed governance envelope (the managed script files copied by bootstrap, `.unicorn-hub/**`, and `.specify/**`) as `linguist-vendored`, so the blueprint's Node scaffolding does not skew the target repo's GitHub language bar. Bootstrap appends this block idempotently and never overwrites an existing consumer `.gitattributes`; product code keeps its language stats.
+- A `.gitattributes` block that marks the installed governance envelope (the managed script files bootstrap actually writes, `.unicorn-hub/**`, and `.specify/**`) as `linguist-vendored`, so the blueprint's Node scaffolding does not skew the target repo's GitHub language bar. Bootstrap appends this block idempotently and never overwrites an existing consumer `.gitattributes`; pre-existing consumer script collisions and product code keep their language stats.
 
 ## Canonical Workflow
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Current profiles include:
 - Local orchestration scripts for worktrees, PR publishing, feature-memory gates, context budget checks, AI review gates, and branch protection
 - GitHub Actions workflows for CI, PR guard, trusted AI review routing, and OSV scanning
 - Supply-chain defaults: pnpm `minimumReleaseAge`, Dependabot cooldown, pinned package manager, lockfile-oriented installs
-- A `.gitattributes` block that marks the installed governance envelope (`scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, so the blueprint's Node scaffolding does not skew the target repo's GitHub language bar. Bootstrap appends this block idempotently and never overwrites an existing consumer `.gitattributes`; product code keeps its language stats.
+- A `.gitattributes` block that marks the installed governance envelope (the managed script files copied by bootstrap, `.unicorn-hub/**`, and `.specify/**`) as `linguist-vendored`, so the blueprint's Node scaffolding does not skew the target repo's GitHub language bar. Bootstrap appends this block idempotently and never overwrites an existing consumer `.gitattributes`; product code keeps its language stats.
 
 ## Canonical Workflow
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Current profiles include:
 - Local orchestration scripts for worktrees, PR publishing, feature-memory gates, context budget checks, AI review gates, and branch protection
 - GitHub Actions workflows for CI, PR guard, trusted AI review routing, and OSV scanning
 - Supply-chain defaults: pnpm `minimumReleaseAge`, Dependabot cooldown, pinned package manager, lockfile-oriented installs
-- A `.gitattributes` block that marks the installed governance envelope (the managed script files bootstrap actually writes, `.unicorn-hub/**`, and `.specify/**`) as `linguist-vendored`, so the blueprint's Node scaffolding does not skew the target repo's GitHub language bar. Bootstrap appends this block idempotently and never overwrites an existing consumer `.gitattributes`; pre-existing consumer script collisions and product code keep their language stats.
+- A `.gitattributes` block that marks the installed governance envelope (the managed script files bootstrap writes or recognizes as unchanged blueprint copies, `.unicorn-hub/**`, and `.specify/**`) as `linguist-vendored`, so the blueprint's Node scaffolding does not skew the target repo's GitHub language bar. Bootstrap appends this block idempotently and never overwrites an existing consumer `.gitattributes`; pre-existing consumer script collisions and product code keep their language stats.
 
 ## Canonical Workflow
 

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -28,7 +28,7 @@ Install:
 - `.unicorn-hub/config.json`
 - `.gitattributes` (governance envelope marked `linguist-vendored`)
 
-The `.gitattributes` block keeps the installed scaffolding (the managed script files bootstrap actually writes, `.unicorn-hub/**`, `.specify/**`) out of the target repository's GitHub Linguist language statistics, so the blueprint's Node automation does not inflate the language bar of, for example, a Python service. Bootstrap appends the managed block idempotently and preserves any pre-existing consumer `.gitattributes`; it never marks product code or pre-existing consumer script collisions as vendored.
+The `.gitattributes` block keeps the installed scaffolding (the managed script files bootstrap writes or recognizes as unchanged blueprint copies, `.unicorn-hub/**`, `.specify/**`) out of the target repository's GitHub Linguist language statistics, so the blueprint's Node automation does not inflate the language bar of, for example, a Python service. Bootstrap appends the managed block idempotently and preserves any pre-existing consumer `.gitattributes`; it never marks product code or pre-existing consumer script collisions as vendored.
 
 The target repository must have a reading route before product code changes begin. For a new or under-documented target, the installed `CREATE-DOCS.md` protocol routes the agent to `docs-minimum.md` first. Use the full interview only when the user asks for deeper discovery or the project direction is unclear. Durable docs are a lazy-loaded index, not mandatory reading for every task.
 

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -28,7 +28,7 @@ Install:
 - `.unicorn-hub/config.json`
 - `.gitattributes` (governance envelope marked `linguist-vendored`)
 
-The `.gitattributes` block keeps the installed scaffolding (the managed script files copied by bootstrap, `.unicorn-hub/**`, `.specify/**`) out of the target repository's GitHub Linguist language statistics, so the blueprint's Node automation does not inflate the language bar of, for example, a Python service. Bootstrap appends the managed block idempotently and preserves any pre-existing consumer `.gitattributes`; it never marks product code as vendored.
+The `.gitattributes` block keeps the installed scaffolding (the managed script files bootstrap actually writes, `.unicorn-hub/**`, `.specify/**`) out of the target repository's GitHub Linguist language statistics, so the blueprint's Node automation does not inflate the language bar of, for example, a Python service. Bootstrap appends the managed block idempotently and preserves any pre-existing consumer `.gitattributes`; it never marks product code or pre-existing consumer script collisions as vendored.
 
 The target repository must have a reading route before product code changes begin. For a new or under-documented target, the installed `CREATE-DOCS.md` protocol routes the agent to `docs-minimum.md` first. Use the full interview only when the user asks for deeper discovery or the project direction is unclear. Durable docs are a lazy-loaded index, not mandatory reading for every task.
 

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -28,7 +28,7 @@ Install:
 - `.unicorn-hub/config.json`
 - `.gitattributes` (governance envelope marked `linguist-vendored`)
 
-The `.gitattributes` block keeps the installed scaffolding (`scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**`) out of the target repository's GitHub Linguist language statistics, so the blueprint's Node automation does not inflate the language bar of, for example, a Python service. Bootstrap appends the managed block idempotently and preserves any pre-existing consumer `.gitattributes`; it never marks product code as vendored.
+The `.gitattributes` block keeps the installed scaffolding (the managed script files copied by bootstrap, `.unicorn-hub/**`, `.specify/**`) out of the target repository's GitHub Linguist language statistics, so the blueprint's Node automation does not inflate the language bar of, for example, a Python service. Bootstrap appends the managed block idempotently and preserves any pre-existing consumer `.gitattributes`; it never marks product code as vendored.
 
 The target repository must have a reading route before product code changes begin. For a new or under-documented target, the installed `CREATE-DOCS.md` protocol routes the agent to `docs-minimum.md` first. Use the full interview only when the user asks for deeper discovery or the project direction is unclear. Durable docs are a lazy-loaded index, not mandatory reading for every task.
 

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -26,6 +26,9 @@ Install:
 - `CLAUDE.md`
 - `docs_project/`
 - `.unicorn-hub/config.json`
+- `.gitattributes` (governance envelope marked `linguist-vendored`)
+
+The `.gitattributes` block keeps the installed scaffolding (`scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**`) out of the target repository's GitHub Linguist language statistics, so the blueprint's Node automation does not inflate the language bar of, for example, a Python service. Bootstrap appends the managed block idempotently and preserves any pre-existing consumer `.gitattributes`; it never marks product code as vendored.
 
 The target repository must have a reading route before product code changes begin. For a new or under-documented target, the installed `CREATE-DOCS.md` protocol routes the agent to `docs-minimum.md` first. Use the full interview only when the user asks for deeper discovery or the project direction is unclear. Durable docs are a lazy-loaded index, not mandatory reading for every task.
 

--- a/docs/portability-and-sanitization.md
+++ b/docs/portability-and-sanitization.md
@@ -12,9 +12,9 @@ This repository must remain a distilled practice blueprint, not an archive of an
 
 ## Language Statistics In Consumer Repositories
 
-Bootstrap installs a managed `.gitattributes` block that marks the governance envelope it actually writes — managed script files, `.unicorn-hub/**`, and `.specify/**` — as `linguist-vendored`. GitHub Linguist honours `.gitattributes` in every clone, so this scaffolding (notably the Node `*.mjs` automation) is excluded from the target repository's language bar and does not skew the language mix of, for example, a Python service.
+Bootstrap installs a managed `.gitattributes` block that marks the governance envelope it writes or recognizes as unchanged blueprint copies — managed script files, `.unicorn-hub/**`, and `.specify/**` — as `linguist-vendored`. GitHub Linguist honours `.gitattributes` in every clone, so this scaffolding (notably the Node `*.mjs` automation) is excluded from the target repository's language bar and does not skew the language mix of, for example, a Python service.
 
-The block is appended idempotently and never overwrites a consumer's existing `.gitattributes`; product code and pre-existing consumer script collisions are never marked as vendored. Verify with `git check-attr linguist-vendored -- scripts/ai-review-gate.mjs` (expect `set`) and against a product file such as `scripts/build.mjs` or a preserved pre-existing `scripts/shared.mjs` (expect `unspecified`), or run `github-linguist` on the repository.
+The block is appended idempotently and never overwrites a consumer's existing `.gitattributes`; product code and pre-existing consumer script collisions are never marked as vendored. Verify with `git check-attr linguist-vendored -- scripts/ai-review-gate.mjs` (expect `set` when the file was written by bootstrap or still matches the blueprint copy) and against a product file such as `scripts/build.mjs` or a preserved pre-existing `scripts/shared.mjs` with different content (expect `unspecified`), or run `github-linguist` on the repository.
 
 ## Sanitizer Scope
 

--- a/docs/portability-and-sanitization.md
+++ b/docs/portability-and-sanitization.md
@@ -10,6 +10,12 @@ This repository must remain a distilled practice blueprint, not an archive of an
 - Keep examples synthetic.
 - Keep scripts configurable through `.unicorn-hub/config.json`.
 
+## Language Statistics In Consumer Repositories
+
+Bootstrap installs a managed `.gitattributes` block that marks the governance envelope it copies in — `scripts/*.mjs`, `.unicorn-hub/**`, and `.specify/**` — as `linguist-vendored`. GitHub Linguist honours `.gitattributes` in every clone, so this scaffolding (notably the Node `*.mjs` automation) is excluded from the target repository's language bar and does not skew the language mix of, for example, a Python service.
+
+The block is appended idempotently and never overwrites a consumer's existing `.gitattributes`; product code is never marked as vendored. Verify with `git check-attr linguist-vendored -- scripts/<file>.mjs` (expect `set`) and against a product file (expect `unspecified`), or run `github-linguist` on the repository.
+
 ## Sanitizer Scope
 
 `scripts/sanitize-blueprint.mjs` checks for:

--- a/docs/portability-and-sanitization.md
+++ b/docs/portability-and-sanitization.md
@@ -12,9 +12,9 @@ This repository must remain a distilled practice blueprint, not an archive of an
 
 ## Language Statistics In Consumer Repositories
 
-Bootstrap installs a managed `.gitattributes` block that marks the governance envelope it copies in — the managed script files copied by bootstrap, `.unicorn-hub/**`, and `.specify/**` — as `linguist-vendored`. GitHub Linguist honours `.gitattributes` in every clone, so this scaffolding (notably the Node `*.mjs` automation) is excluded from the target repository's language bar and does not skew the language mix of, for example, a Python service.
+Bootstrap installs a managed `.gitattributes` block that marks the governance envelope it actually writes — managed script files, `.unicorn-hub/**`, and `.specify/**` — as `linguist-vendored`. GitHub Linguist honours `.gitattributes` in every clone, so this scaffolding (notably the Node `*.mjs` automation) is excluded from the target repository's language bar and does not skew the language mix of, for example, a Python service.
 
-The block is appended idempotently and never overwrites a consumer's existing `.gitattributes`; product code is never marked as vendored. Verify with `git check-attr linguist-vendored -- scripts/ai-review-gate.mjs` (expect `set`) and against a product file such as `scripts/build.mjs` (expect `unspecified`), or run `github-linguist` on the repository.
+The block is appended idempotently and never overwrites a consumer's existing `.gitattributes`; product code and pre-existing consumer script collisions are never marked as vendored. Verify with `git check-attr linguist-vendored -- scripts/ai-review-gate.mjs` (expect `set`) and against a product file such as `scripts/build.mjs` or a preserved pre-existing `scripts/shared.mjs` (expect `unspecified`), or run `github-linguist` on the repository.
 
 ## Sanitizer Scope
 

--- a/docs/portability-and-sanitization.md
+++ b/docs/portability-and-sanitization.md
@@ -12,9 +12,9 @@ This repository must remain a distilled practice blueprint, not an archive of an
 
 ## Language Statistics In Consumer Repositories
 
-Bootstrap installs a managed `.gitattributes` block that marks the governance envelope it copies in — `scripts/*.mjs`, `.unicorn-hub/**`, and `.specify/**` — as `linguist-vendored`. GitHub Linguist honours `.gitattributes` in every clone, so this scaffolding (notably the Node `*.mjs` automation) is excluded from the target repository's language bar and does not skew the language mix of, for example, a Python service.
+Bootstrap installs a managed `.gitattributes` block that marks the governance envelope it copies in — the managed script files copied by bootstrap, `.unicorn-hub/**`, and `.specify/**` — as `linguist-vendored`. GitHub Linguist honours `.gitattributes` in every clone, so this scaffolding (notably the Node `*.mjs` automation) is excluded from the target repository's language bar and does not skew the language mix of, for example, a Python service.
 
-The block is appended idempotently and never overwrites a consumer's existing `.gitattributes`; product code is never marked as vendored. Verify with `git check-attr linguist-vendored -- scripts/<file>.mjs` (expect `set`) and against a product file (expect `unspecified`), or run `github-linguist` on the repository.
+The block is appended idempotently and never overwrites a consumer's existing `.gitattributes`; product code is never marked as vendored. Verify with `git check-attr linguist-vendored -- scripts/ai-review-gate.mjs` (expect `set`) and against a product file such as `scripts/build.mjs` (expect `unspecified`), or run `github-linguist` on the repository.
 
 ## Sanitizer Scope
 

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -103,9 +103,35 @@ function copyFileFromSource(sourceFile, targetFile, { template = true } = {}) {
   }
 }
 
+const GITATTRIBUTES_MARKER = "# >>> unicorn-hub governance (managed block";
+
+function mergeGitattributes(sourceFile, targetFile) {
+  const block = readFileSync(sourceFile, "utf8").replace(/\s*$/, "\n");
+  const target = join(targetRoot, targetFile);
+  if (!existsSync(target)) {
+    planned.push({ action: "create", target: targetFile });
+    if (!dryRun) {
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, block);
+    }
+    return;
+  }
+  const existing = readFileSync(target, "utf8");
+  if (existing.includes(GITATTRIBUTES_MARKER)) {
+    planned.push({ action: "skip", target: targetFile });
+    return;
+  }
+  planned.push({ action: "merge", target: targetFile });
+  if (!dryRun) {
+    const separator = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+    writeFileSync(target, `${existing}${separator}\n${block}`);
+  }
+}
+
 const excludeTemplates = new Set(profile.excludeTemplates || []);
 for (const rel of walkFiles(join(sourceRoot, "templates"))) {
   if (rel === ".unicorn-hub/config.json") continue;
+  if (rel === ".gitattributes") continue;
   if (excludeTemplates.has(rel)) {
     planned.push({ action: "exclude", target: rel });
     continue;
@@ -133,6 +159,11 @@ const scriptAllowlist = new Set([
 for (const rel of walkFiles(join(sourceRoot, "scripts"))) {
   if (!scriptAllowlist.has(rel)) continue;
   copyFileFromSource(join(sourceRoot, "scripts", rel), join("scripts", rel), { template: false });
+}
+
+const gitattributesSource = join(sourceRoot, "templates", ".gitattributes");
+if (existsSync(gitattributesSource)) {
+  mergeGitattributes(gitattributesSource, ".gitattributes");
 }
 
 const config = {

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -88,25 +88,53 @@ function renderDependabot(updates) {
 
 function copyFileFromSource(sourceFile, targetFile, { template = true } = {}) {
   const target = join(targetRoot, targetFile);
-  if (existsSync(target) && !force) {
+  const targetExists = existsSync(target);
+  if (targetExists && !force) {
     planned.push({ action: "skip", target: targetFile });
-    return;
+    return "skip";
   }
   const raw = readFileSync(sourceFile, "utf8");
   const content = targetFile === ".github/dependabot.yml" && Array.isArray(profile.dependabotUpdates)
     ? renderDependabot(profile.dependabotUpdates)
     : template ? replacePlaceholders(raw, replacements) : raw;
-  planned.push({ action: existsSync(target) ? "overwrite" : "create", target: targetFile });
+  const action = targetExists ? "overwrite" : "create";
+  planned.push({ action, target: targetFile });
   if (!dryRun) {
     mkdirSync(dirname(target), { recursive: true });
     writeFileSync(target, content);
   }
+  return action;
 }
 
 const GITATTRIBUTES_MARKER = "# >>> unicorn-hub governance (managed block";
+const GITATTRIBUTES_END_MARKER = "# <<< unicorn-hub governance (managed block";
 
-function mergeGitattributes(sourceFile, targetFile) {
-  const block = readFileSync(sourceFile, "utf8").replace(/\s*$/, "\n");
+function renderGitattributesBlock(sourceFile, managedScriptTargets = new Set()) {
+  return readFileSync(sourceFile, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => {
+      const scriptRule = line.match(/^(scripts\/[^\s]+)\s+linguist-vendored\b/);
+      return !scriptRule || managedScriptTargets.has(scriptRule[1]);
+    })
+    .join("\n")
+    .replace(/\s*$/, "\n");
+}
+
+function replaceManagedGitattributesBlock(existing, block) {
+  const begin = existing.indexOf(GITATTRIBUTES_MARKER);
+  const end = existing.indexOf(GITATTRIBUTES_END_MARKER, begin);
+  if (begin === -1 || end === -1) return null;
+  const nextLine = existing.indexOf("\n", end);
+  const endOffset = nextLine === -1 ? existing.length : nextLine + 1;
+  return [
+    existing.slice(0, begin).replace(/\s*$/, ""),
+    block.trimEnd(),
+    existing.slice(endOffset).replace(/^\s*/, "")
+  ].filter(Boolean).join("\n\n") + "\n";
+}
+
+function mergeGitattributes(sourceFile, targetFile, { managedScriptTargets = new Set() } = {}) {
+  const block = renderGitattributesBlock(sourceFile, managedScriptTargets);
   const target = join(targetRoot, targetFile);
   if (!existsSync(target)) {
     planned.push({ action: "create", target: targetFile });
@@ -118,7 +146,14 @@ function mergeGitattributes(sourceFile, targetFile) {
   }
   const existing = readFileSync(target, "utf8");
   if (existing.includes(GITATTRIBUTES_MARKER)) {
-    planned.push({ action: "skip", target: targetFile });
+    if (!force) {
+      planned.push({ action: "skip", target: targetFile });
+      return;
+    }
+    planned.push({ action: "update", target: targetFile });
+    if (!dryRun) {
+      writeFileSync(target, replaceManagedGitattributesBlock(existing, block) || existing);
+    }
     return;
   }
   planned.push({ action: "merge", target: targetFile });
@@ -156,14 +191,18 @@ const scriptAllowlist = new Set([
   "apply-branch-protection.mjs"
 ]);
 
+const managedScriptTargets = new Set();
 for (const rel of walkFiles(join(sourceRoot, "scripts"))) {
   if (!scriptAllowlist.has(rel)) continue;
-  copyFileFromSource(join(sourceRoot, "scripts", rel), join("scripts", rel), { template: false });
+  const action = copyFileFromSource(join(sourceRoot, "scripts", rel), join("scripts", rel), { template: false });
+  if (action === "create" || action === "overwrite") {
+    managedScriptTargets.add(`scripts/${rel}`);
+  }
 }
 
 const gitattributesSource = join(sourceRoot, "templates", ".gitattributes");
 if (existsSync(gitattributesSource)) {
-  mergeGitattributes(gitattributesSource, ".gitattributes");
+  mergeGitattributes(gitattributesSource, ".gitattributes", { managedScriptTargets });
 }
 
 const config = {
@@ -224,7 +263,7 @@ for (const item of planned) {
 
 console.log("");
 const targetLabel = relative(process.cwd(), targetRoot) || ".";
-const wroteSomething = planned.some(item => item.action === "create" || item.action === "overwrite" || item.action === "scripts");
+const wroteSomething = planned.some(item => ["create", "overwrite", "merge", "update", "scripts"].includes(item.action));
 
 if (dryRun) {
   console.log(`Dry run for Unicorn Hub blueprint profile '${profileId}' against ${targetLabel}. Nothing was written. Re-run without --dry-run to apply.`);

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -133,6 +133,11 @@ function replaceManagedGitattributesBlock(existing, block) {
   ].filter(Boolean).join("\n\n") + "\n";
 }
 
+function targetMatchesSource(sourceFile, targetFile) {
+  const target = join(targetRoot, targetFile);
+  return existsSync(target) && readFileSync(target, "utf8") === readFileSync(sourceFile, "utf8");
+}
+
 function mergeGitattributes(sourceFile, targetFile, { managedScriptTargets = new Set() } = {}) {
   const block = renderGitattributesBlock(sourceFile, managedScriptTargets);
   const target = join(targetRoot, targetFile);
@@ -194,8 +199,10 @@ const scriptAllowlist = new Set([
 const managedScriptTargets = new Set();
 for (const rel of walkFiles(join(sourceRoot, "scripts"))) {
   if (!scriptAllowlist.has(rel)) continue;
-  const action = copyFileFromSource(join(sourceRoot, "scripts", rel), join("scripts", rel), { template: false });
-  if (action === "create" || action === "overwrite") {
+  const sourceFile = join(sourceRoot, "scripts", rel);
+  const targetFile = join("scripts", rel);
+  const action = copyFileFromSource(sourceFile, targetFile, { template: false });
+  if (action === "create" || action === "overwrite" || targetMatchesSource(sourceFile, targetFile)) {
     managedScriptTargets.add(`scripts/${rel}`);
   }
 }

--- a/specs/011-vendor-governance-linguist/plan.md
+++ b/specs/011-vendor-governance-linguist/plan.md
@@ -33,7 +33,7 @@ The only new mechanism is a marker-guarded append. The managed block lives in `t
 | Acceptance criterion | Evidence |
 | --- | --- |
 | AC-001 | Bootstrap test asserts the installed `.gitattributes` contains the managed marker, explicit managed script entries, and the `.unicorn-hub/**` / `.specify/**` rules. |
-| AC-002 | Bootstrap test runs `git init` in the target and asserts `git check-attr linguist-vendored` is `set` for managed scripts, `.unicorn-hub/**`, `.specify/**` and `unspecified` for consumer/product code such as `scripts/build.mjs`, `src/main.py`, and `app/index.ts`; a manual `python-service` run is captured in Process Memory. |
+| AC-002 | Bootstrap test runs `git init` in the target and asserts `git check-attr linguist-vendored` is `set` for managed scripts bootstrap writes, `.unicorn-hub/**`, `.specify/**` and `unspecified` for consumer/product code such as `scripts/build.mjs`, a preserved pre-existing `scripts/shared.mjs`, `src/main.py`, and `app/index.ts`; a manual `python-service` run is captured in Process Memory. |
 | AC-003 | Merge test seeds a consumer `.gitattributes`, asserts the original rules survive verbatim and ahead of the appended block, and that bootstrap reports a `merge` action. |
 | AC-004 | Merge test re-runs bootstrap, asserts a `skip` action, byte-identical output, and a single occurrence of the managed rules. |
 | AC-005 | README, `docs/bootstrap-flow.md`, and `docs/portability-and-sanitization.md` state the envelope is vendored and excluded from the consumer language bar. |
@@ -41,14 +41,14 @@ The only new mechanism is a marker-guarded append. The managed block lives in `t
 Negative scenario evidence:
 
 - The `git check-attr` assertions prove product code (`src`, `app`) stays `unspecified` (NS-001).
-- The consumer-merge test proves existing entries are preserved (NS-002).
+- The consumer-merge test proves existing entries are preserved (NS-002), and the collision test proves a preserved consumer `scripts/shared.mjs` is not vendored (NS-005).
 - The diff touches only `templates/.gitattributes`, bootstrap merge wiring, tests, and docs; no script body changes (NS-003).
 - `pnpm run preflight` runs the sanitizer to confirm no private or source-project residue (NS-004).
 
 ## Risks
 
-- Risk: A broad glob could vendor consumer files.
-  Mitigation: the managed block lists the exact script filenames copied by bootstrap; `.unicorn-hub/**` and `.specify/**` are governance-only directories.
+- Risk: A broad glob or static filename list could vendor consumer files.
+  Mitigation: the managed block lists only script filenames bootstrap actually creates or overwrites during the install; `.unicorn-hub/**` and `.specify/**` are governance-only directories.
 - Risk: A naive copy would skip or overwrite an existing consumer `.gitattributes`.
   Mitigation: a dedicated marker-guarded merge appends instead of copying through the skip-if-exists template path.
 - Risk: Re-running bootstrap could duplicate the block.

--- a/specs/011-vendor-governance-linguist/plan.md
+++ b/specs/011-vendor-governance-linguist/plan.md
@@ -1,0 +1,55 @@
+# Plan: Vendor Governance Envelope For Linguist
+
+## Summary
+
+Ship a managed `.gitattributes` block as a template, teach bootstrap to merge it idempotently into target repositories without clobbering consumer rules, and add tests plus docs so the governance envelope stays out of consumer language statistics.
+
+## Technical Context
+
+- runtime: Node.js ESM scripts
+- dependencies: no new dependencies (git used only by tests for `check-attr` evidence)
+- product paths: templates, scripts, tests, docs, specs
+- data changes: none
+
+## Scope Boundaries
+
+- in scope: `templates/.gitattributes`, bootstrap merge logic, bootstrap tests, README/bootstrap-flow/portability docs
+- out of scope: governance script bodies, AI review workflow semantics, branch protection defaults, durable project-docs vendoring
+
+## Constitution Check
+
+- Spec-first: this feature folder records the change before publish.
+- Testable boundaries: Node tests cover installation, `git check-attr` outcomes, consumer merge, and idempotent re-run.
+- PR-only: changes are prepared on an isolated feature branch.
+- Simplicity: the merge reuses existing fs helpers and a single marker guard; no Markdown/glob parser is added.
+- Deployability: preflight remains a local command and target profiles keep their stack-native checks.
+
+## Complexity Tracking
+
+The only new mechanism is a marker-guarded append. The managed block lives in `templates/.gitattributes` and is skipped by the generic template walk (like `.unicorn-hub/config.json`) so it is handled exactly once by a dedicated merge step. The merge does not parse `.gitattributes`; it appends a block when a stable begin marker is absent and skips when present.
+
+## Verification
+
+| Acceptance criterion | Evidence |
+| --- | --- |
+| AC-001 | Bootstrap test asserts the installed `.gitattributes` contains the managed marker and the three `linguist-vendored` rules. |
+| AC-002 | Bootstrap test runs `git init` in the target and asserts `git check-attr linguist-vendored` is `set` for `scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**` and `unspecified` for `src/main.py` and `app/index.ts`; a manual `python-service` run is captured in Process Memory. |
+| AC-003 | Merge test seeds a consumer `.gitattributes`, asserts the original rules survive verbatim and ahead of the appended block, and that bootstrap reports a `merge` action. |
+| AC-004 | Merge test re-runs bootstrap, asserts a `skip` action, byte-identical output, and a single occurrence of the managed rules. |
+| AC-005 | README, `docs/bootstrap-flow.md`, and `docs/portability-and-sanitization.md` state the envelope is vendored and excluded from the consumer language bar. |
+
+Negative scenario evidence:
+
+- The `git check-attr` assertions prove product code (`src`, `app`) stays `unspecified` (NS-001).
+- The consumer-merge test proves existing entries are preserved (NS-002).
+- The diff touches only `templates/.gitattributes`, bootstrap merge wiring, tests, and docs; no script body changes (NS-003).
+- `pnpm run preflight` runs the sanitizer to confirm no private or source-project residue (NS-004).
+
+## Risks
+
+- Risk: A broad glob could vendor consumer files.
+  Mitigation: `scripts/*.mjs` matches only the flat governance scripts; `.unicorn-hub/**` and `.specify/**` are governance-only directories.
+- Risk: A naive copy would skip or overwrite an existing consumer `.gitattributes`.
+  Mitigation: a dedicated marker-guarded merge appends instead of copying through the skip-if-exists template path.
+- Risk: Re-running bootstrap could duplicate the block.
+  Mitigation: a stable begin marker makes the merge idempotent; tests assert a single occurrence.

--- a/specs/011-vendor-governance-linguist/plan.md
+++ b/specs/011-vendor-governance-linguist/plan.md
@@ -33,7 +33,7 @@ The only new mechanism is a marker-guarded append. The managed block lives in `t
 | Acceptance criterion | Evidence |
 | --- | --- |
 | AC-001 | Bootstrap test asserts the installed `.gitattributes` contains the managed marker, explicit managed script entries, and the `.unicorn-hub/**` / `.specify/**` rules. |
-| AC-002 | Bootstrap test runs `git init` in the target and asserts `git check-attr linguist-vendored` is `set` for managed scripts bootstrap writes, `.unicorn-hub/**`, `.specify/**` and `unspecified` for consumer/product code such as `scripts/build.mjs`, a preserved pre-existing `scripts/shared.mjs`, `src/main.py`, and `app/index.ts`; a manual `python-service` run is captured in Process Memory. |
+| AC-002 | Bootstrap test runs `git init` in the target and asserts `git check-attr linguist-vendored` is `set` for managed scripts bootstrap writes or recognizes as unchanged blueprint copies, `.unicorn-hub/**`, `.specify/**` and `unspecified` for consumer/product code such as `scripts/build.mjs`, a preserved pre-existing `scripts/shared.mjs` with different content, `src/main.py`, and `app/index.ts`; a manual `python-service` run is captured in Process Memory. |
 | AC-003 | Merge test seeds a consumer `.gitattributes`, asserts the original rules survive verbatim and ahead of the appended block, and that bootstrap reports a `merge` action. |
 | AC-004 | Merge test re-runs bootstrap, asserts a `skip` action, byte-identical output, and a single occurrence of the managed rules. |
 | AC-005 | README, `docs/bootstrap-flow.md`, and `docs/portability-and-sanitization.md` state the envelope is vendored and excluded from the consumer language bar. |
@@ -41,14 +41,14 @@ The only new mechanism is a marker-guarded append. The managed block lives in `t
 Negative scenario evidence:
 
 - The `git check-attr` assertions prove product code (`src`, `app`) stays `unspecified` (NS-001).
-- The consumer-merge test proves existing entries are preserved (NS-002), and the collision test proves a preserved consumer `scripts/shared.mjs` is not vendored (NS-005).
+- The consumer-merge test proves existing entries are preserved (NS-002), the collision test proves a preserved consumer `scripts/shared.mjs` is not vendored (NS-005), and the existing-managed test proves already-bootstrapped matching scripts are vendored.
 - The diff touches only `templates/.gitattributes`, bootstrap merge wiring, tests, and docs; no script body changes (NS-003).
 - `pnpm run preflight` runs the sanitizer to confirm no private or source-project residue (NS-004).
 
 ## Risks
 
 - Risk: A broad glob or static filename list could vendor consumer files.
-  Mitigation: the managed block lists only script filenames bootstrap actually creates or overwrites during the install; `.unicorn-hub/**` and `.specify/**` are governance-only directories.
+  Mitigation: the managed block lists only script filenames bootstrap creates, overwrites, or verifies as unchanged blueprint copies during the install; `.unicorn-hub/**` and `.specify/**` are governance-only directories.
 - Risk: A naive copy would skip or overwrite an existing consumer `.gitattributes`.
   Mitigation: a dedicated marker-guarded merge appends instead of copying through the skip-if-exists template path.
 - Risk: Re-running bootstrap could duplicate the block.

--- a/specs/011-vendor-governance-linguist/plan.md
+++ b/specs/011-vendor-governance-linguist/plan.md
@@ -32,8 +32,8 @@ The only new mechanism is a marker-guarded append. The managed block lives in `t
 
 | Acceptance criterion | Evidence |
 | --- | --- |
-| AC-001 | Bootstrap test asserts the installed `.gitattributes` contains the managed marker and the three `linguist-vendored` rules. |
-| AC-002 | Bootstrap test runs `git init` in the target and asserts `git check-attr linguist-vendored` is `set` for `scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**` and `unspecified` for `src/main.py` and `app/index.ts`; a manual `python-service` run is captured in Process Memory. |
+| AC-001 | Bootstrap test asserts the installed `.gitattributes` contains the managed marker, explicit managed script entries, and the `.unicorn-hub/**` / `.specify/**` rules. |
+| AC-002 | Bootstrap test runs `git init` in the target and asserts `git check-attr linguist-vendored` is `set` for managed scripts, `.unicorn-hub/**`, `.specify/**` and `unspecified` for consumer/product code such as `scripts/build.mjs`, `src/main.py`, and `app/index.ts`; a manual `python-service` run is captured in Process Memory. |
 | AC-003 | Merge test seeds a consumer `.gitattributes`, asserts the original rules survive verbatim and ahead of the appended block, and that bootstrap reports a `merge` action. |
 | AC-004 | Merge test re-runs bootstrap, asserts a `skip` action, byte-identical output, and a single occurrence of the managed rules. |
 | AC-005 | README, `docs/bootstrap-flow.md`, and `docs/portability-and-sanitization.md` state the envelope is vendored and excluded from the consumer language bar. |
@@ -48,7 +48,7 @@ Negative scenario evidence:
 ## Risks
 
 - Risk: A broad glob could vendor consumer files.
-  Mitigation: `scripts/*.mjs` matches only the flat governance scripts; `.unicorn-hub/**` and `.specify/**` are governance-only directories.
+  Mitigation: the managed block lists the exact script filenames copied by bootstrap; `.unicorn-hub/**` and `.specify/**` are governance-only directories.
 - Risk: A naive copy would skip or overwrite an existing consumer `.gitattributes`.
   Mitigation: a dedicated marker-guarded merge appends instead of copying through the skip-if-exists template path.
 - Risk: Re-running bootstrap could duplicate the block.

--- a/specs/011-vendor-governance-linguist/spec.md
+++ b/specs/011-vendor-governance-linguist/spec.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Stop the Unicorn Hub governance envelope from skewing the GitHub Linguist language statistics of consumer repositories by shipping a managed `.gitattributes` block that marks the installed scaffolding (the managed script files bootstrap actually writes, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, installed idempotently and without clobbering a consumer's own `.gitattributes`.
+Stop the Unicorn Hub governance envelope from skewing the GitHub Linguist language statistics of consumer repositories by shipping a managed `.gitattributes` block that marks the installed scaffolding (the managed script files bootstrap writes or recognizes as unchanged blueprint copies, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, installed idempotently and without clobbering a consumer's own `.gitattributes`.
 
 ## Scope
 
@@ -12,6 +12,7 @@ In scope:
 - bootstrap logic that creates or appends the managed block idempotently and preserves existing consumer `.gitattributes` rules
 - tests proving the block is installed, that `git check-attr` reports the envelope as vendored and product code as unspecified, and that a pre-existing `.gitattributes` is merged not overwritten
 - tests proving pre-existing consumer script collisions remain unvendored when bootstrap preserves them
+- tests proving unchanged pre-existing managed scripts are still vendored for already-bootstrapped repositories
 - documentation updates noting the envelope is vendored and excluded from the consumer language bar
 
 Out of scope:
@@ -53,7 +54,7 @@ As a maintainer, I want to confirm with `git check-attr` that the scaffolding is
 ## Requirements
 
 - FR-001: Add `templates/.gitattributes` as the managed-block source of truth with a stable begin/end marker.
-- FR-002: Make `scripts/bootstrap-repo.mjs` merge `.gitattributes` idempotently (create when missing, append when the marker is absent, skip when present) instead of copying it through the skip-if-exists template path; script rules are filtered to the managed scripts bootstrap actually creates or overwrites.
+- FR-002: Make `scripts/bootstrap-repo.mjs` merge `.gitattributes` idempotently (create when missing, append when the marker is absent, skip when present) instead of copying it through the skip-if-exists template path; script rules are filtered to the managed scripts bootstrap creates, overwrites, or finds unchanged from the blueprint source.
 - FR-003: Add tests for installation, `git check-attr` outcomes, consumer-merge preservation, and idempotent re-run.
 - FR-004: Update README, bootstrap flow, and portability docs to record the vendored governance envelope.
 

--- a/specs/011-vendor-governance-linguist/spec.md
+++ b/specs/011-vendor-governance-linguist/spec.md
@@ -1,0 +1,68 @@
+# Spec: Vendor Governance Envelope For Linguist
+
+## Goal
+
+Stop the Unicorn Hub governance envelope from skewing the GitHub Linguist language statistics of consumer repositories by shipping a managed `.gitattributes` block that marks the installed scaffolding (`scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, installed idempotently and without clobbering a consumer's own `.gitattributes`.
+
+## Scope
+
+In scope:
+
+- a source-of-truth `templates/.gitattributes` managed block that vendors the copied governance paths
+- bootstrap logic that creates or appends the managed block idempotently and preserves existing consumer `.gitattributes` rules
+- tests proving the block is installed, that `git check-attr` reports the envelope as vendored and product code as unspecified, and that a pre-existing `.gitattributes` is merged not overwritten
+- documentation updates noting the envelope is vendored and excluded from the consumer language bar
+
+Out of scope:
+
+- editing, deleting, or rewriting the governance scripts themselves (they remain CI dependencies)
+- marking product code, durable project docs, or consumer-authored files as vendored
+- changing GitHub review backends, branch protection, or CI semantics
+
+## User Stories
+
+### US1: Honest Language Bar Downstream
+
+As the owner of a Python service that adopted Unicorn Hub, I want the blueprint's Node `*.mjs` automation excluded from my repository's language statistics so that GitHub does not report a large fake JavaScript share.
+
+### US2: Non-Destructive Install
+
+As a consumer who already maintains a `.gitattributes`, I want bootstrap to append its governance rules without overwriting my existing entries so that my own attributes keep working.
+
+### US3: Verifiable Exclusion
+
+As a maintainer, I want to confirm with `git check-attr` that the scaffolding is vendored while product code is not so that I can trust the exclusion is correct.
+
+## Acceptance Criteria
+
+- AC-001: Bootstrap installs a `.gitattributes` containing a managed block that marks `scripts/*.mjs`, `.unicorn-hub/**`, and `.specify/**` as `linguist-vendored`.
+- AC-002: For a bootstrapped target, `git check-attr linguist-vendored` reports `set` for the governance paths and `unspecified` for product code such as `src/*.py` and `app/*.ts`.
+- AC-003: When the target already has a `.gitattributes`, bootstrap appends the managed block after the existing content and preserves the consumer's rules verbatim.
+- AC-004: Re-running bootstrap is idempotent: the managed marker is detected and the block is neither duplicated nor rewritten.
+- AC-005: Documentation states that the governance envelope is marked vendored and is excluded from the consumer's GitHub language statistics.
+
+## Negative Scenarios
+
+- NS-001: The change must not mark product code or consumer-authored project docs as vendored.
+- NS-002: The change must not overwrite or discard a consumer's pre-existing `.gitattributes` entries.
+- NS-003: The change must not edit, remove, or rewrite the governance scripts that CI depends on.
+- NS-004: The change must not add private URLs, source-project residue, secrets, production IDs, or personal paths.
+
+## Requirements
+
+- FR-001: Add `templates/.gitattributes` as the managed-block source of truth with a stable begin/end marker.
+- FR-002: Make `scripts/bootstrap-repo.mjs` merge `.gitattributes` idempotently (create when missing, append when the marker is absent, skip when present) instead of copying it through the skip-if-exists template path.
+- FR-003: Add tests for installation, `git check-attr` outcomes, consumer-merge preservation, and idempotent re-run.
+- FR-004: Update README, bootstrap flow, and portability docs to record the vendored governance envelope.
+
+## Success Criteria
+
+- SC-001: `pnpm run preflight` passes.
+- SC-002: A synthetic bootstrapped target reports the governance envelope as `linguist-vendored: set` and product code as `unspecified`.
+- SC-003: A pre-existing consumer `.gitattributes` is preserved and the managed block appears exactly once after re-running bootstrap.
+
+## Assumptions
+
+- GitHub Linguist honours `.gitattributes` in every clone, so distributing markings through bootstrap is sufficient.
+- The governance scripts all land flat in `scripts/` as `*.mjs`, so `scripts/*.mjs` is a precise, product-safe glob.
+- `.unicorn-hub/**` and `.specify/**` contain only governance scaffolding, never consumer product code.

--- a/specs/011-vendor-governance-linguist/spec.md
+++ b/specs/011-vendor-governance-linguist/spec.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Stop the Unicorn Hub governance envelope from skewing the GitHub Linguist language statistics of consumer repositories by shipping a managed `.gitattributes` block that marks the installed scaffolding (`scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, installed idempotently and without clobbering a consumer's own `.gitattributes`.
+Stop the Unicorn Hub governance envelope from skewing the GitHub Linguist language statistics of consumer repositories by shipping a managed `.gitattributes` block that marks the installed scaffolding (the managed script files copied by bootstrap, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, installed idempotently and without clobbering a consumer's own `.gitattributes`.
 
 ## Scope
 
@@ -35,7 +35,7 @@ As a maintainer, I want to confirm with `git check-attr` that the scaffolding is
 
 ## Acceptance Criteria
 
-- AC-001: Bootstrap installs a `.gitattributes` containing a managed block that marks `scripts/*.mjs`, `.unicorn-hub/**`, and `.specify/**` as `linguist-vendored`.
+- AC-001: Bootstrap installs a `.gitattributes` containing a managed block that marks the managed script filenames copied by bootstrap, `.unicorn-hub/**`, and `.specify/**` as `linguist-vendored`.
 - AC-002: For a bootstrapped target, `git check-attr linguist-vendored` reports `set` for the governance paths and `unspecified` for product code such as `src/*.py` and `app/*.ts`.
 - AC-003: When the target already has a `.gitattributes`, bootstrap appends the managed block after the existing content and preserves the consumer's rules verbatim.
 - AC-004: Re-running bootstrap is idempotent: the managed marker is detected and the block is neither duplicated nor rewritten.
@@ -64,5 +64,5 @@ As a maintainer, I want to confirm with `git check-attr` that the scaffolding is
 ## Assumptions
 
 - GitHub Linguist honours `.gitattributes` in every clone, so distributing markings through bootstrap is sufficient.
-- The governance scripts all land flat in `scripts/` as `*.mjs`, so `scripts/*.mjs` is a precise, product-safe glob.
+- The governance scripts all land as known flat `scripts/*.mjs` filenames, so the managed block can list those copied filenames without covering consumer-authored scripts.
 - `.unicorn-hub/**` and `.specify/**` contain only governance scaffolding, never consumer product code.

--- a/specs/011-vendor-governance-linguist/spec.md
+++ b/specs/011-vendor-governance-linguist/spec.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Stop the Unicorn Hub governance envelope from skewing the GitHub Linguist language statistics of consumer repositories by shipping a managed `.gitattributes` block that marks the installed scaffolding (the managed script files copied by bootstrap, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, installed idempotently and without clobbering a consumer's own `.gitattributes`.
+Stop the Unicorn Hub governance envelope from skewing the GitHub Linguist language statistics of consumer repositories by shipping a managed `.gitattributes` block that marks the installed scaffolding (the managed script files bootstrap actually writes, `.unicorn-hub/**`, `.specify/**`) as `linguist-vendored`, installed idempotently and without clobbering a consumer's own `.gitattributes`.
 
 ## Scope
 
@@ -11,6 +11,7 @@ In scope:
 - a source-of-truth `templates/.gitattributes` managed block that vendors the copied governance paths
 - bootstrap logic that creates or appends the managed block idempotently and preserves existing consumer `.gitattributes` rules
 - tests proving the block is installed, that `git check-attr` reports the envelope as vendored and product code as unspecified, and that a pre-existing `.gitattributes` is merged not overwritten
+- tests proving pre-existing consumer script collisions remain unvendored when bootstrap preserves them
 - documentation updates noting the envelope is vendored and excluded from the consumer language bar
 
 Out of scope:
@@ -47,11 +48,12 @@ As a maintainer, I want to confirm with `git check-attr` that the scaffolding is
 - NS-002: The change must not overwrite or discard a consumer's pre-existing `.gitattributes` entries.
 - NS-003: The change must not edit, remove, or rewrite the governance scripts that CI depends on.
 - NS-004: The change must not add private URLs, source-project residue, secrets, production IDs, or personal paths.
+- NS-005: The change must not mark a pre-existing consumer-owned `scripts/*.mjs` collision as vendored when bootstrap skips that file.
 
 ## Requirements
 
 - FR-001: Add `templates/.gitattributes` as the managed-block source of truth with a stable begin/end marker.
-- FR-002: Make `scripts/bootstrap-repo.mjs` merge `.gitattributes` idempotently (create when missing, append when the marker is absent, skip when present) instead of copying it through the skip-if-exists template path.
+- FR-002: Make `scripts/bootstrap-repo.mjs` merge `.gitattributes` idempotently (create when missing, append when the marker is absent, skip when present) instead of copying it through the skip-if-exists template path; script rules are filtered to the managed scripts bootstrap actually creates or overwrites.
 - FR-003: Add tests for installation, `git check-attr` outcomes, consumer-merge preservation, and idempotent re-run.
 - FR-004: Update README, bootstrap flow, and portability docs to record the vendored governance envelope.
 

--- a/specs/011-vendor-governance-linguist/tasks.md
+++ b/specs/011-vendor-governance-linguist/tasks.md
@@ -7,7 +7,7 @@
 
 ## Implementation
 
-- [x] T003 Add `templates/.gitattributes` managed block vendoring `scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**`.
+- [x] T003 Add `templates/.gitattributes` managed block vendoring the managed script filenames copied by bootstrap, `.unicorn-hub/**`, `.specify/**`.
 - [x] T004 Skip `.gitattributes` in the generic template walk and add an idempotent merge step in `scripts/bootstrap-repo.mjs`.
 - [x] T005 Update README, `docs/bootstrap-flow.md`, and `docs/portability-and-sanitization.md`.
 
@@ -25,7 +25,7 @@
 
 ### Decisions
 
-- Mark only `scripts/*.mjs`, `.unicorn-hub/**`, and `.specify/**` as vendored. These are the only installed paths that reach GitHub's language bar (JavaScript) or are pure governance scaffolding; markdown/JSON/YAML are `prose`/`data` and already excluded by Linguist, and `docs_project/` stays consumer-owned and counted.
+- Mark only the managed script filenames copied by bootstrap, `.unicorn-hub/**`, and `.specify/**` as vendored. These are the only installed paths that reach GitHub's language bar (JavaScript) or are pure governance scaffolding; markdown/JSON/YAML are `prose`/`data` and already excluded by Linguist, and `docs_project/` stays consumer-owned and counted.
 - Use `linguist-vendored` (third-party copied-in code), not `linguist-generated`: nothing here is a build artifact.
 - Guard idempotency with a stable begin marker; append the block when absent, skip when present, create when no `.gitattributes` exists.
 - Keep `templates/.gitattributes` as the source of truth and exclude it from the generic walk, mirroring how `.unicorn-hub/config.json` is handled.

--- a/specs/011-vendor-governance-linguist/tasks.md
+++ b/specs/011-vendor-governance-linguist/tasks.md
@@ -7,7 +7,7 @@
 
 ## Implementation
 
-- [x] T003 Add `templates/.gitattributes` managed block vendoring the managed script filenames bootstrap actually writes, `.unicorn-hub/**`, `.specify/**`.
+- [x] T003 Add `templates/.gitattributes` managed block vendoring the managed script filenames bootstrap writes or recognizes as unchanged blueprint copies, `.unicorn-hub/**`, `.specify/**`.
 - [x] T004 Skip `.gitattributes` in the generic template walk and add an idempotent merge step in `scripts/bootstrap-repo.mjs`.
 - [x] T005 Update README, `docs/bootstrap-flow.md`, and `docs/portability-and-sanitization.md`.
 
@@ -25,8 +25,9 @@
 
 ### Decisions
 
-- Mark only the managed script filenames bootstrap actually writes, `.unicorn-hub/**`, and `.specify/**` as vendored. These are the only installed paths that reach GitHub's language bar (JavaScript) or are pure governance scaffolding; markdown/JSON/YAML are `prose`/`data` and already excluded by Linguist, and `docs_project/` stays consumer-owned and counted.
+- Mark only the managed script filenames bootstrap writes or recognizes as unchanged blueprint copies, `.unicorn-hub/**`, and `.specify/**` as vendored. These are the only installed paths that reach GitHub's language bar (JavaScript) or are pure governance scaffolding; markdown/JSON/YAML are `prose`/`data` and already excluded by Linguist, and `docs_project/` stays consumer-owned and counted.
 - If a consumer already owns a colliding `scripts/*.mjs` filename, bootstrap skips that file and filters its corresponding attribute line so the consumer script remains counted.
+- If an existing script matches the blueprint source exactly, bootstrap treats it as an already-managed copy and includes its attribute line.
 - Use `linguist-vendored` (third-party copied-in code), not `linguist-generated`: nothing here is a build artifact.
 - Guard idempotency with a stable begin marker; append the block when absent, skip when present, create when no `.gitattributes` exists.
 - Keep `templates/.gitattributes` as the source of truth and exclude it from the generic walk, mirroring how `.unicorn-hub/config.json` is handled.

--- a/specs/011-vendor-governance-linguist/tasks.md
+++ b/specs/011-vendor-governance-linguist/tasks.md
@@ -7,7 +7,7 @@
 
 ## Implementation
 
-- [x] T003 Add `templates/.gitattributes` managed block vendoring the managed script filenames copied by bootstrap, `.unicorn-hub/**`, `.specify/**`.
+- [x] T003 Add `templates/.gitattributes` managed block vendoring the managed script filenames bootstrap actually writes, `.unicorn-hub/**`, `.specify/**`.
 - [x] T004 Skip `.gitattributes` in the generic template walk and add an idempotent merge step in `scripts/bootstrap-repo.mjs`.
 - [x] T005 Update README, `docs/bootstrap-flow.md`, and `docs/portability-and-sanitization.md`.
 
@@ -25,7 +25,8 @@
 
 ### Decisions
 
-- Mark only the managed script filenames copied by bootstrap, `.unicorn-hub/**`, and `.specify/**` as vendored. These are the only installed paths that reach GitHub's language bar (JavaScript) or are pure governance scaffolding; markdown/JSON/YAML are `prose`/`data` and already excluded by Linguist, and `docs_project/` stays consumer-owned and counted.
+- Mark only the managed script filenames bootstrap actually writes, `.unicorn-hub/**`, and `.specify/**` as vendored. These are the only installed paths that reach GitHub's language bar (JavaScript) or are pure governance scaffolding; markdown/JSON/YAML are `prose`/`data` and already excluded by Linguist, and `docs_project/` stays consumer-owned and counted.
+- If a consumer already owns a colliding `scripts/*.mjs` filename, bootstrap skips that file and filters its corresponding attribute line so the consumer script remains counted.
 - Use `linguist-vendored` (third-party copied-in code), not `linguist-generated`: nothing here is a build artifact.
 - Guard idempotency with a stable begin marker; append the block when absent, skip when present, create when no `.gitattributes` exists.
 - Keep `templates/.gitattributes` as the source of truth and exclude it from the generic walk, mirroring how `.unicorn-hub/config.json` is handled.

--- a/specs/011-vendor-governance-linguist/tasks.md
+++ b/specs/011-vendor-governance-linguist/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: Vendor Governance Envelope For Linguist
+
+## Setup
+
+- [x] T001 Identify the exact bootstrap copy manifest (template walk + script allowlist) and map destination paths.
+- [x] T002 Create feature memory for the Linguist-vendoring change.
+
+## Implementation
+
+- [x] T003 Add `templates/.gitattributes` managed block vendoring `scripts/*.mjs`, `.unicorn-hub/**`, `.specify/**`.
+- [x] T004 Skip `.gitattributes` in the generic template walk and add an idempotent merge step in `scripts/bootstrap-repo.mjs`.
+- [x] T005 Update README, `docs/bootstrap-flow.md`, and `docs/portability-and-sanitization.md`.
+
+## Verification
+
+- [x] T006 Add bootstrap tests for installation, `git check-attr` outcomes, consumer merge preservation, and idempotent re-run.
+- [x] T007 Capture manual `git check-attr` evidence against a synthetic `python-service` target.
+- [x] T008 Run `pnpm run preflight`.
+
+## Process Memory
+
+### Dead Ends
+
+- Copying `.gitattributes` through the normal template walk was rejected: `copyFileFromSource` skips when the target exists, so a consumer `.gitattributes` would never receive the governance rules. A dedicated merge step was required.
+
+### Decisions
+
+- Mark only `scripts/*.mjs`, `.unicorn-hub/**`, and `.specify/**` as vendored. These are the only installed paths that reach GitHub's language bar (JavaScript) or are pure governance scaffolding; markdown/JSON/YAML are `prose`/`data` and already excluded by Linguist, and `docs_project/` stays consumer-owned and counted.
+- Use `linguist-vendored` (third-party copied-in code), not `linguist-generated`: nothing here is a build artifact.
+- Guard idempotency with a stable begin marker; append the block when absent, skip when present, create when no `.gitattributes` exists.
+- Keep `templates/.gitattributes` as the source of truth and exclude it from the generic walk, mirroring how `.unicorn-hub/config.json` is handled.
+
+### Known Issues
+
+- Manual evidence (`python-service` target): `scripts/ai-review-gate.mjs`, `.unicorn-hub/config.json`, and `.specify/templates/spec-template.md` reported `linguist-vendored: set`; `src/bot.py` and `app/main.ts` reported `linguist-vendored: unspecified`.
+- `pnpm run preflight` passed locally after adding the feature folder.

--- a/templates/.gitattributes
+++ b/templates/.gitattributes
@@ -1,0 +1,11 @@
+# >>> unicorn-hub governance (managed block — bootstrap maintains this) >>>
+# Keep the Unicorn Hub bootstrap envelope out of GitHub Linguist language
+# statistics in consumer repositories. The paths below are copied in verbatim
+# by scripts/bootstrap-repo.mjs and are process scaffolding, not product code,
+# so they should not skew a repo's language bar (e.g. governance *.mjs scripts
+# inflating JavaScript in a Python project). Rules outside this managed block
+# are preserved when bootstrap is re-run.
+scripts/*.mjs        linguist-vendored
+.unicorn-hub/**      linguist-vendored
+.specify/**          linguist-vendored
+# <<< unicorn-hub governance (managed block — bootstrap maintains this) <<<

--- a/templates/.gitattributes
+++ b/templates/.gitattributes
@@ -1,11 +1,22 @@
 # >>> unicorn-hub governance (managed block — bootstrap maintains this) >>>
 # Keep the Unicorn Hub bootstrap envelope out of GitHub Linguist language
 # statistics in consumer repositories. The paths below are copied in verbatim
-# by scripts/bootstrap-repo.mjs and are process scaffolding, not product code,
-# so they should not skew a repo's language bar (e.g. governance *.mjs scripts
-# inflating JavaScript in a Python project). Rules outside this managed block
-# are preserved when bootstrap is re-run.
-scripts/*.mjs        linguist-vendored
-.unicorn-hub/**      linguist-vendored
-.specify/**          linguist-vendored
+# by scripts/bootstrap-repo.mjs and are process scaffolding, not product code.
+# Rules outside this managed block are preserved when bootstrap is re-run.
+scripts/ai-command-policy.mjs          linguist-vendored
+scripts/ai-review-gate.mjs             linguist-vendored
+scripts/ai-review-helpers.mjs          linguist-vendored
+scripts/ai-review-rerun.mjs            linguist-vendored
+scripts/apply-branch-protection.mjs    linguist-vendored
+scripts/check-context-budget.mjs       linguist-vendored
+scripts/check-feature-memory.mjs       linguist-vendored
+scripts/check-repo-baseline.mjs        linguist-vendored
+scripts/new-worktree.mjs               linguist-vendored
+scripts/publish-branch.mjs             linguist-vendored
+scripts/resolve-pr-context.mjs         linguist-vendored
+scripts/set-implementation-agent.mjs   linguist-vendored
+scripts/shared.mjs                     linguist-vendored
+scripts/switch-review-agent.mjs        linguist-vendored
+.unicorn-hub/**                        linguist-vendored
+.specify/**                            linguist-vendored
 # <<< unicorn-hub governance (managed block — bootstrap maintains this) <<<

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -574,6 +574,39 @@ test("bootstrap installs a .gitattributes that vendors the governance envelope",
   assert.match(checkAttr("app/index.ts"), /linguist-vendored: unspecified$/);
 });
 
+test("bootstrap does not vendor pre-existing consumer script collisions", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-gitattributes-collision-"));
+  mkdirSync(join(target, "scripts"), { recursive: true });
+  writeFileSync(join(target, "scripts/shared.mjs"), "console.log('consumer-owned script');\n");
+
+  const output = run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Collision Linguist"
+  ]);
+  assert.match(output, /^skip\s+scripts\/shared\.mjs$/m);
+
+  const gitattributes = readFileSync(join(target, ".gitattributes"), "utf8");
+  assert.doesNotMatch(gitattributes, /^scripts\/shared\.mjs\s+linguist-vendored$/m);
+  assert.match(gitattributes, /^scripts\/ai-review-gate\.mjs\s+linguist-vendored$/m);
+
+  execFileSync("git", ["init", "-q"], { cwd: target });
+  const checkAttr = (path) =>
+    execFileSync("git", ["check-attr", "linguist-vendored", "--", path], {
+      cwd: target,
+      encoding: "utf8"
+    }).trim();
+
+  assert.match(checkAttr("scripts/shared.mjs"), /linguist-vendored: unspecified$/);
+  assert.match(checkAttr("scripts/ai-review-gate.mjs"), /linguist-vendored: set$/);
+});
+
 test("bootstrap merges into a pre-existing consumer .gitattributes without clobbering it", () => {
   const target = mkdtempSync(join(tmpdir(), "unicorn-gitattributes-merge-"));
   const consumerRules = "*.py text eol=lf\nvendor/** linguist-vendored\n";

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -607,6 +607,43 @@ test("bootstrap does not vendor pre-existing consumer script collisions", () => 
   assert.match(checkAttr("scripts/ai-review-gate.mjs"), /linguist-vendored: set$/);
 });
 
+test("bootstrap vendors skipped scripts that already match the managed blueprint", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-gitattributes-existing-managed-"));
+  mkdirSync(join(target, "scripts"), { recursive: true });
+  writeFileSync(
+    join(target, "scripts/ai-review-gate.mjs"),
+    readFileSync(join(root, "scripts/ai-review-gate.mjs"), "utf8")
+  );
+
+  const output = run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Existing Managed Linguist"
+  ]);
+  assert.match(output, /^skip\s+scripts\/ai-review-gate\.mjs$/m);
+
+  const gitattributes = readFileSync(join(target, ".gitattributes"), "utf8");
+  assert.match(gitattributes, /^scripts\/ai-review-gate\.mjs\s+linguist-vendored$/m);
+
+  execFileSync("git", ["init", "-q"], { cwd: target });
+  const checkAttr = execFileSync("git", [
+    "check-attr",
+    "linguist-vendored",
+    "--",
+    "scripts/ai-review-gate.mjs"
+  ], {
+    cwd: target,
+    encoding: "utf8"
+  }).trim();
+  assert.match(checkAttr, /linguist-vendored: set$/);
+});
+
 test("bootstrap merges into a pre-existing consumer .gitattributes without clobbering it", () => {
   const target = mkdtempSync(join(tmpdir(), "unicorn-gitattributes-merge-"));
   const consumerRules = "*.py text eol=lf\nvendor/** linguist-vendored\n";

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -548,13 +548,17 @@ test("bootstrap installs a .gitattributes that vendors the governance envelope",
 
   const gitattributes = readFileSync(join(target, ".gitattributes"), "utf8");
   assert.match(gitattributes, /# >>> unicorn-hub governance \(managed block/);
-  assert.match(gitattributes, /^scripts\/\*\.mjs\s+linguist-vendored$/m);
+  assert.doesNotMatch(gitattributes, /^scripts\/\*\.mjs\s+linguist-vendored$/m);
+  assert.match(gitattributes, /^scripts\/ai-review-gate\.mjs\s+linguist-vendored$/m);
+  assert.match(gitattributes, /^scripts\/shared\.mjs\s+linguist-vendored$/m);
+  assert.match(gitattributes, /^scripts\/apply-branch-protection\.mjs\s+linguist-vendored$/m);
   assert.match(gitattributes, /^\.unicorn-hub\/\*\*\s+linguist-vendored$/m);
   assert.match(gitattributes, /^\.specify\/\*\*\s+linguist-vendored$/m);
 
   // Linguist honours .gitattributes via git check-attr; prove the envelope is
   // vendored while product code keeps its language stats.
   execFileSync("git", ["init", "-q"], { cwd: target });
+  writeFileSync(join(target, "scripts/build.mjs"), "console.log('consumer product script');\n");
   const checkAttr = (path) =>
     execFileSync("git", ["check-attr", "linguist-vendored", "--", path], {
       cwd: target,
@@ -565,6 +569,7 @@ test("bootstrap installs a .gitattributes that vendors the governance envelope",
   assert.match(checkAttr(".unicorn-hub/config.json"), /linguist-vendored: set$/);
   assert.match(checkAttr(".specify/memory/constitution.md"), /linguist-vendored: set$/);
   // Product code must NOT be vendored.
+  assert.match(checkAttr("scripts/build.mjs"), /linguist-vendored: unspecified$/);
   assert.match(checkAttr("src/main.py"), /linguist-vendored: unspecified$/);
   assert.match(checkAttr("app/index.ts"), /linguist-vendored: unspecified$/);
 });
@@ -594,7 +599,7 @@ test("bootstrap merges into a pre-existing consumer .gitattributes without clobb
   // Governance block is appended after them.
   assert.match(merged, /# >>> unicorn-hub governance \(managed block/);
   assert.ok(
-    merged.indexOf("vendor/** linguist-vendored") < merged.indexOf("scripts/*.mjs"),
+    merged.indexOf("vendor/** linguist-vendored") < merged.indexOf("scripts/ai-command-policy.mjs"),
     "consumer rules must remain ahead of the appended managed block"
   );
 
@@ -614,7 +619,7 @@ test("bootstrap merges into a pre-existing consumer .gitattributes without clobb
   const reMerged = readFileSync(join(target, ".gitattributes"), "utf8");
   assert.equal(reMerged, merged, "idempotent re-run must not change .gitattributes");
   assert.equal(
-    reMerged.match(/scripts\/\*\.mjs/g).length,
+    reMerged.match(/scripts\/ai-command-policy\.mjs/g).length,
     1,
     "managed block must not be duplicated on re-run"
   );

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -531,6 +531,95 @@ test("baseline check ignores excludeTemplates entries outside the profile-safe a
   assert.match(stderr, /AGENTS\.md/, "baseline error should name the missing required path");
 });
 
+test("bootstrap installs a .gitattributes that vendors the governance envelope", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-gitattributes-"));
+
+  run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Synthetic Linguist"
+  ]);
+
+  const gitattributes = readFileSync(join(target, ".gitattributes"), "utf8");
+  assert.match(gitattributes, /# >>> unicorn-hub governance \(managed block/);
+  assert.match(gitattributes, /^scripts\/\*\.mjs\s+linguist-vendored$/m);
+  assert.match(gitattributes, /^\.unicorn-hub\/\*\*\s+linguist-vendored$/m);
+  assert.match(gitattributes, /^\.specify\/\*\*\s+linguist-vendored$/m);
+
+  // Linguist honours .gitattributes via git check-attr; prove the envelope is
+  // vendored while product code keeps its language stats.
+  execFileSync("git", ["init", "-q"], { cwd: target });
+  const checkAttr = (path) =>
+    execFileSync("git", ["check-attr", "linguist-vendored", "--", path], {
+      cwd: target,
+      encoding: "utf8"
+    }).trim();
+
+  assert.match(checkAttr("scripts/ai-review-gate.mjs"), /linguist-vendored: set$/);
+  assert.match(checkAttr(".unicorn-hub/config.json"), /linguist-vendored: set$/);
+  assert.match(checkAttr(".specify/memory/constitution.md"), /linguist-vendored: set$/);
+  // Product code must NOT be vendored.
+  assert.match(checkAttr("src/main.py"), /linguist-vendored: unspecified$/);
+  assert.match(checkAttr("app/index.ts"), /linguist-vendored: unspecified$/);
+});
+
+test("bootstrap merges into a pre-existing consumer .gitattributes without clobbering it", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-gitattributes-merge-"));
+  const consumerRules = "*.py text eol=lf\nvendor/** linguist-vendored\n";
+  writeFileSync(join(target, ".gitattributes"), consumerRules);
+
+  const firstRun = run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Merge Linguist"
+  ]);
+  assert.match(firstRun, /^merge\s+\.gitattributes$/m);
+
+  const merged = readFileSync(join(target, ".gitattributes"), "utf8");
+  // Consumer rules survive verbatim.
+  assert.match(merged, /\*\.py text eol=lf/);
+  assert.match(merged, /vendor\/\*\* linguist-vendored/);
+  // Governance block is appended after them.
+  assert.match(merged, /# >>> unicorn-hub governance \(managed block/);
+  assert.ok(
+    merged.indexOf("vendor/** linguist-vendored") < merged.indexOf("scripts/*.mjs"),
+    "consumer rules must remain ahead of the appended managed block"
+  );
+
+  // Re-run is idempotent: the managed marker is detected, nothing re-appended.
+  const secondRun = run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Merge Linguist"
+  ]);
+  assert.match(secondRun, /^skip\s+\.gitattributes$/m);
+  const reMerged = readFileSync(join(target, ".gitattributes"), "utf8");
+  assert.equal(reMerged, merged, "idempotent re-run must not change .gitattributes");
+  assert.equal(
+    reMerged.match(/scripts\/\*\.mjs/g).length,
+    1,
+    "managed block must not be duplicated on re-run"
+  );
+});
+
 test("bootstrap into pre-existing package.json preserves user-defined baseline scripts", () => {
   const target = mkdtempSync(join(tmpdir(), "unicorn-flutter-preserve-baseline-"));
   writeFileSync(join(target, "pubspec.yaml"), "name: synthetic_flutter_app\n");


### PR DESCRIPTION
## Problem

When unicorn-hub bootstraps its governance envelope into a downstream repo, the Node governance scripts can be counted by GitHub Linguist and inflate JavaScript stats in projects that do not otherwise contain product JS. Linguist honors `.gitattributes` in every clone, so these markings can be distributed centrally through bootstrap.

## What this does

- Adds [`templates/.gitattributes`](templates/.gitattributes), a marker-guarded managed block for bootstrap-owned governance scaffolding:
  - `.unicorn-hub/**` and `.specify/**`
  - only managed script files that bootstrap copies, overwrites, or recognizes as exact blueprint matches
- Teaches `bootstrap-repo.mjs` to merge `.gitattributes` idempotently and filter script entries to actual managed targets.
- Keeps pre-existing consumer script collisions unvendored unless their contents exactly match the Unicorn Hub blueprint.
- Leaves product code (`src/`, `app/`, consumer-owned scripts, etc.) in the language bar.

Scope constraint honored: no governance script bodies were changed except the bootstrap installer behavior required to make the Linguist envelope precise.

## Evidence (`git check-attr` on synthetic targets)

```text
scripts/ai-review-gate.mjs:          linguist-vendored: set
.unicorn-hub/config.json:            linguist-vendored: set
.specify/templates/spec-template.md: linguist-vendored: set
scripts/build.mjs:                   linguist-vendored: unspecified
scripts/shared.mjs:                  linguist-vendored: unspecified
src/bot.py:                          linguist-vendored: unspecified
app/main.ts:                         linguist-vendored: unspecified
```

The assertions are encoded in `tests/bootstrap.test.mjs`, including install, consumer merge preservation, idempotent rerun, pre-existing consumer script collisions, and already-bootstrapped matching managed scripts.

## Verification

- `pnpm run preflight` passes locally (54 tests plus sanitizer, baseline, feature-memory, context-budget, syntax check, and workflow parity).
- GitHub checks pass on `a835abf132a2ef53e16bf6c30a0da196034dba4f`: PR Guard, CI baseline-checks, OSV Scan, and AI Review.
- Feature memory: `specs/011-vendor-governance-linguist/`.

## Docs

README, `docs/bootstrap-flow.md`, `docs/portability-and-sanitization.md`, and feature memory describe the precise vendored governance envelope and collision behavior.

Co-authored-by: Codex <codex@openai.com>
