### PR TITLE
Fix Dependabot update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,11 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -39,3 +41,8 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -24,16 +24,22 @@ minimumReleaseAge: 10080
 
 That is seven days in minutes. It prevents freshly published packages from being installed immediately after release.
 
-## Dependabot Cooldown
+## Dependabot Cooldown and Grouping
 
-Dependabot should run weekly with cooldown:
+Dependabot should run weekly. Every configured ecosystem groups `minor` and `patch`
+updates in the `minor-and-patch` group.
+
+Semver-aware ecosystems use these cooldowns:
 
 - default: 7 days
 - major: 14 days
 - minor: 7 days
 - patch: 3 days
 
-Profiles should include only ecosystems that match the target repository. JavaScript-oriented profiles use `npm`; Flutter profiles should use `pub`; all profiles can keep `github-actions` for workflow updates.
+`github-actions` is the exception: it uses only the seven-day default cooldown and
+must not include `semver-*-days` fields. Profiles should include only ecosystems that
+match the target repository. JavaScript-oriented profiles use `npm`; Flutter profiles
+use `pub`; all profiles can keep `github-actions` for workflow updates.
 
 ## GitHub Actions
 

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -76,10 +76,21 @@ function renderDependabot(updates) {
       `      prefix: "${String(update.commitMessage?.prefix || update["commit-message"]?.prefix || "chore")}"`,
       "      include: \"scope\"",
       "    cooldown:",
-      `      default-days: ${Number(update.cooldown?.defaultDays ?? update.cooldown?.["default-days"] ?? 7)}`,
-      `      semver-major-days: ${Number(update.cooldown?.semverMajorDays ?? update.cooldown?.["semver-major-days"] ?? 14)}`,
-      `      semver-minor-days: ${Number(update.cooldown?.semverMinorDays ?? update.cooldown?.["semver-minor-days"] ?? 7)}`,
-      `      semver-patch-days: ${Number(update.cooldown?.semverPatchDays ?? update.cooldown?.["semver-patch-days"] ?? 3)}`
+      `      default-days: ${Number(update.cooldown?.defaultDays ?? update.cooldown?.["default-days"] ?? 7)}`
+    );
+    if (ecosystem !== "github-actions") {
+      lines.push(
+        `      semver-major-days: ${Number(update.cooldown?.semverMajorDays ?? update.cooldown?.["semver-major-days"] ?? 14)}`,
+        `      semver-minor-days: ${Number(update.cooldown?.semverMinorDays ?? update.cooldown?.["semver-minor-days"] ?? 7)}`,
+        `      semver-patch-days: ${Number(update.cooldown?.semverPatchDays ?? update.cooldown?.["semver-patch-days"] ?? 3)}`
+      );
+    }
+    lines.push(
+      "    groups:",
+      "      minor-and-patch:",
+      "        update-types:",
+      "          - \"minor\"",
+      "          - \"patch\""
     );
     return lines.join("\n");
   });

--- a/specs/012-portable-dependabot-grouping/plan.md
+++ b/specs/012-portable-dependabot-grouping/plan.md
@@ -24,6 +24,7 @@ Synchronize the checked-in configuration, template, and bootstrap renderer so ev
 | AC-002 | Bootstrap test asserts `minor-and-patch` contains both allowed update types for GitHub Actions and pub. |
 | AC-003 | A direct parity test compares the root Dependabot configuration with its template counterpart. |
 | AC-004 | Existing explicit-zero renderer test remains green. |
+| Documentation | Supply-chain guidance distinguishes the GitHub Actions cooldown exception and the per-ecosystem grouping policy. |
 
 ## Risks
 

--- a/specs/012-portable-dependabot-grouping/plan.md
+++ b/specs/012-portable-dependabot-grouping/plan.md
@@ -1,0 +1,33 @@
+# Plan: Portable Dependabot Grouping
+
+## Summary
+
+Synchronize the checked-in configuration, template, and bootstrap renderer so every installed repository receives the same safe Dependabot behavior.
+
+## Technical Context
+
+- runtime: Node.js ESM bootstrap script
+- dependencies: none added
+- product paths: templates, scripts, tests, specs
+- data changes: no dependency or lockfile updates
+
+## Scope Boundaries
+
+- in scope: Dependabot template, renderer, and generation tests
+- out of scope: package upgrades and workflow scheduling changes
+
+## Verification
+
+| Acceptance criterion | Evidence |
+| --- | --- |
+| AC-001 | Flutter-profile bootstrap test asserts the GitHub Actions section contains only `default-days`. |
+| AC-002 | Bootstrap test asserts `minor-and-patch` contains both allowed update types for GitHub Actions and pub. |
+| AC-003 | Root and template Dependabot files are updated together and verified by the repository workflow-sync gate. |
+| AC-004 | Existing explicit-zero renderer test remains green. |
+
+## Risks
+
+- Risk: a root-only configuration change would leave generated repositories stale.
+  Mitigation: update the template and renderer in the same commit, with generated-output assertions.
+- Risk: broadly removing semantic cooldown fields would change non-Actions ecosystems.
+  Mitigation: condition renderer behavior on the `github-actions` ecosystem only.

--- a/specs/012-portable-dependabot-grouping/plan.md
+++ b/specs/012-portable-dependabot-grouping/plan.md
@@ -22,7 +22,7 @@ Synchronize the checked-in configuration, template, and bootstrap renderer so ev
 | --- | --- |
 | AC-001 | Flutter-profile bootstrap test asserts the GitHub Actions section contains only `default-days`. |
 | AC-002 | Bootstrap test asserts `minor-and-patch` contains both allowed update types for GitHub Actions and pub. |
-| AC-003 | Root and template Dependabot files are updated together and verified by the repository workflow-sync gate. |
+| AC-003 | A direct parity test compares the root Dependabot configuration with its template counterpart. |
 | AC-004 | Existing explicit-zero renderer test remains green. |
 
 ## Risks

--- a/specs/012-portable-dependabot-grouping/spec.md
+++ b/specs/012-portable-dependabot-grouping/spec.md
@@ -1,0 +1,43 @@
+# Spec: Portable Dependabot Grouping
+
+## Goal
+
+Keep Dependabot configuration valid and consistent both in Unicorn Hub and in repositories bootstrapped from it: GitHub Actions uses only the supported default cooldown, and each ecosystem groups minor and patch updates.
+
+## Scope
+
+In scope:
+
+- the root Dependabot configuration and its template counterpart
+- bootstrap rendering of profile-defined Dependabot updates
+- tests covering the generated GitHub Actions and pub configuration
+
+Out of scope:
+
+- changing dependency versions or lockfiles
+- adding or removing monitored ecosystems
+- altering Dependabot schedules, labels, or pull-request limits
+
+## Acceptance Criteria
+
+- AC-001: GitHub Actions keeps `cooldown.default-days` and has no `semver-*-days` keys.
+- AC-002: Every generated ecosystem configuration groups `minor` and `patch` updates under `minor-and-patch`.
+- AC-003: The template mirrors the root Dependabot configuration for the npm and GitHub Actions ecosystems.
+- AC-004: Bootstrap rendering preserves explicit non-GitHub-Actions cooldown values, including zero values.
+
+## Negative Scenarios
+
+- NS-001: Bootstrap must not emit unsupported semantic-version cooldown keys for GitHub Actions.
+- NS-002: The change must not modify application dependencies or lockfiles.
+- NS-003: Profile-specific ecosystems such as `pub` must retain their configurable semantic-version cooldowns.
+
+## Requirements
+
+- FR-001: Render only `default-days` in a GitHub Actions cooldown block.
+- FR-002: Render a per-ecosystem minor-and-patch group for bootstrap-provided Dependabot updates.
+- FR-003: Prove the generated Flutter profile configuration has the expected GitHub Actions and pub behavior.
+
+## Success Criteria
+
+- SC-001: `pnpm run preflight` passes.
+- SC-002: Bootstrap tests prove the rendered configuration meets AC-001 through AC-004.

--- a/specs/012-portable-dependabot-grouping/tasks.md
+++ b/specs/012-portable-dependabot-grouping/tasks.md
@@ -17,6 +17,7 @@
 - [x] T007 Run the complete preflight after feature memory is present.
 - [x] T008 Push the fix and request a new Codex review.
 - [x] T009 Add a direct root/template parity test so preflight catches future Dependabot drift.
+- [x] T010 Document the GitHub Actions cooldown exception and per-ecosystem grouping policy.
 
 ## Process Memory
 

--- a/specs/012-portable-dependabot-grouping/tasks.md
+++ b/specs/012-portable-dependabot-grouping/tasks.md
@@ -16,6 +16,7 @@
 - [x] T006 Run the focused bootstrap test suite.
 - [x] T007 Run the complete preflight after feature memory is present.
 - [x] T008 Push the fix and request a new Codex review.
+- [x] T009 Add a direct root/template parity test so preflight catches future Dependabot drift.
 
 ## Process Memory
 

--- a/specs/012-portable-dependabot-grouping/tasks.md
+++ b/specs/012-portable-dependabot-grouping/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Portable Dependabot Grouping
+
+## Setup
+
+- [x] T001 Inspect the root configuration, template, profiles, and bootstrap renderer.
+- [x] T002 Create feature memory before publishing the bootstrap changes.
+
+## Implementation
+
+- [x] T003 Update root and template Dependabot configurations with per-ecosystem minor-and-patch groups.
+- [x] T004 Render GitHub Actions cooldowns without semantic-version keys while preserving them for other ecosystems.
+- [x] T005 Add generated Flutter profile assertions for both cooldown and grouping behavior.
+
+## Verification
+
+- [x] T006 Run the focused bootstrap test suite.
+- [x] T007 Run the complete preflight after feature memory is present.
+- [x] T008 Push the fix and request a new Codex review.
+
+## Process Memory
+
+### Decisions
+
+- Keep the semantic-version cooldown settings for non-GitHub-Actions ecosystems so existing profile behavior and explicit-zero values remain intact.
+- Treat grouping as a setting on each generated ecosystem entry rather than combining ecosystems into one Dependabot pull request.
+
+### Known Issues
+
+- The initial PR-only configuration change did not update bootstrapped targets; the Codex review correctly identified the missing template and renderer propagation.

--- a/templates/.github/dependabot.yml
+++ b/templates/.github/dependabot.yml
@@ -16,9 +16,11 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -39,3 +41,8 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -246,6 +246,13 @@ test("bootstrap preserves Flutter CI and installs Flutter profile controls", () 
   assert.match(dependabot, /package-ecosystem: "pub"/);
   assert.doesNotMatch(dependabot, /package-ecosystem: "npm"/);
 
+  const [githubActionsDependabot, pubDependabot] = dependabot.split('  - package-ecosystem: "pub"');
+  assert.match(githubActionsDependabot, /cooldown:\n      default-days: 7/);
+  assert.doesNotMatch(githubActionsDependabot, /semver-\w+-days/);
+  assert.match(githubActionsDependabot, /groups:\n      minor-and-patch:\n        update-types:\n          - "minor"\n          - "patch"/);
+  assert.match(pubDependabot, /semver-major-days: 14/);
+  assert.match(pubDependabot, /groups:\n      minor-and-patch:\n        update-types:\n          - "minor"\n          - "patch"/);
+
   for (const docPath of [
     "AGENTS.md",
     "README.md",

--- a/tests/workflows.test.mjs
+++ b/tests/workflows.test.mjs
@@ -1,7 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 const root = resolve(".");
 
@@ -12,4 +13,11 @@ test("root workflows stay generated from templates", () => {
   });
 
   assert.match(output, /Root workflows match templates/);
+});
+
+test("root Dependabot configuration stays in sync with its template", () => {
+  const rootConfig = readFileSync(join(root, ".github", "dependabot.yml"), "utf8");
+  const templateConfig = readFileSync(join(root, "templates", ".github", "dependabot.yml"), "utf8");
+
+  assert.equal(rootConfig, templateConfig);
 });


### PR DESCRIPTION
## Summary

- remove unsupported semantic-version cooldown settings from the GitHub Actions configuration while retaining `default-days`
- group minor and patch version updates separately within the GitHub Actions and npm ecosystems
- leave dependency versions unchanged

## Validation

- `pnpm run preflight`

Co-authored-by: Codex <codex@openai.com>