### PR TITLE
Default published PRs to ready for review

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ Current profiles include:
 2. Create feature memory before product code: `spec.md`, `plan.md`, `tasks.md`.
 3. Implement in one worktree, one branch, one PR.
 4. Run local preflight before every push.
-5. Let CI, PR guard, and AI review fail closed.
-6. Merge only after required checks are green and blocking review findings are resolved.
+5. Publish PRs ready for review by default; use `node scripts/publish-branch.mjs --draft` only when a draft is intentional.
+6. Let CI, PR guard, and AI review fail closed.
+7. Merge only after required checks are green and blocking review findings are resolved.
 
 ## After Bootstrap
 

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -114,6 +114,6 @@ The first feature validates the whole system after minimum project docs are pres
 3. write `spec.md`, `plan.md`, `tasks.md`
 4. implement only scoped changes
 5. run preflight
-6. publish PR
+6. publish a ready-for-review PR; use `node scripts/publish-branch.mjs --draft` only when a draft is intentional
 7. trigger AI review from a trusted human account
 8. merge only after all gates are green

--- a/docs/github-ci-and-branch-protection.md
+++ b/docs/github-ci-and-branch-protection.md
@@ -2,6 +2,12 @@
 
 GitHub is the control plane for pull requests, checks, and AI review routing.
 
+## PR Publication Default
+
+`node scripts/publish-branch.mjs` creates a ready-for-review pull request by
+default. Pass `--draft` only when the author explicitly wants to keep the pull
+request in draft state.
+
 ## Required Workflows
 
 - `ci.yml`: runs repository baseline checks as `baseline-checks`, unless a stack-specific profile preserves an existing target CI workflow

--- a/scripts/publish-branch.mjs
+++ b/scripts/publish-branch.mjs
@@ -33,6 +33,7 @@ run("git", ["push", "-u", "origin", branch]);
 const repo = run("gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], { capture: true });
 const base = args.base || config.defaultBaseBranch || "main";
 const title = args.title || `[agent] ${branch.replace(/^[^/]+\//, "").replaceAll("-", " ")}`;
+const draftArgs = args.draft ? ["--draft"] : [];
 const body = [
   "## Summary",
   "",
@@ -60,7 +61,7 @@ try {
     base,
     "--head",
     branch,
-    "--draft",
+    ...draftArgs,
     "--title",
     title,
     "--body-file",

--- a/specs/012-ready-pr-publication-default/plan.md
+++ b/specs/012-ready-pr-publication-default/plan.md
@@ -1,0 +1,51 @@
+# Plan: Ready PR Publication Default
+
+## Summary
+
+Remove unconditional `--draft` from the canonical publisher, add it conditionally for the explicit option, and lock the behavior through mocked GitHub CLI tests, bootstrap coverage, and aligned workflow documentation.
+
+## Technical Context
+
+- runtime: Node.js ESM scripts
+- dependencies: no new dependencies; Node test runner and synthetic command shims
+- product paths: scripts, templates, tests, docs, and specs
+- data changes: none
+
+## Scope Boundaries
+
+- in scope: publisher argument construction, installation coverage, PR-publication documentation, and tests
+- out of scope: GitHub Actions definitions, required check configuration, review routing, branch protection, and merge operations
+
+## Constitution Check
+
+- Spec-first: this feature folder records behavior and evidence before publication.
+- Testable boundaries: tests capture `gh pr create` arguments for both modes without network writes.
+- PR-only: changes are prepared on an isolated branch and will be reviewed through GitHub.
+- Simplicity: a single conditional argument array uses the existing generic argument parser.
+- Deployability: the installed script remains a direct bootstrap copy with no profile-specific configuration.
+
+## Complexity Tracking
+
+No new abstraction is required. The publisher already parses flags, so a small conditional array makes the mode explicit while retaining the existing command structure.
+
+## Verification
+
+| Acceptance criterion | Evidence |
+| --- | --- |
+| AC-001 | `tests/publish-branch.test.mjs` runs the publisher with synthetic `git`, `pnpm`, and `gh` commands and asserts the created PR command omits `--draft`. |
+| AC-002 | `tests/publish-branch.test.mjs` runs the same publisher with `--draft` and asserts the created PR command includes `--draft`. |
+| AC-003 | `tests/bootstrap.test.mjs` asserts bootstrap installs `scripts/publish-branch.mjs` byte-for-byte from the source blueprint. |
+| AC-004 | README, bootstrap flow, GitHub control-plane docs, and installed README/devops workflow docs describe ready-by-default and explicit draft behavior. |
+
+Negative scenario evidence:
+
+- The two publisher tests prove default runs do not create drafts and explicit draft runs retain the flag (NS-001, NS-002).
+- The inspected diff is limited to the publisher, installation coverage, relevant docs, tests, and this feature memory (NS-003).
+- `pnpm run preflight` runs the sanitizer over the changed synthetic content (NS-004).
+
+## Risks
+
+- Risk: a future edit reintroduces unconditional draft mode.
+  Mitigation: tests inspect the exact effective GitHub CLI argument list for both modes.
+- Risk: newly bootstrapped repositories diverge from the source workflow.
+  Mitigation: bootstrap test compares the installed publisher to the canonical source.

--- a/specs/012-ready-pr-publication-default/spec.md
+++ b/specs/012-ready-pr-publication-default/spec.md
@@ -1,0 +1,61 @@
+# Spec: Ready PR Publication Default
+
+## Goal
+
+Make the canonical Unicorn Hub PR publisher open pull requests ready for review by default while retaining draft creation as an explicit author choice.
+
+## Scope
+
+In scope:
+
+- `scripts/publish-branch.mjs` argument handling for ready and draft PR creation
+- bootstrap coverage that preserves the canonical publisher in installed repositories
+- documentation for the source blueprint and installed workflow
+- automated tests for both publication modes
+
+Out of scope:
+
+- changing branch protection, required checks, review evidence, or merge authority
+- changing unrelated bootstrap templates or profile behavior
+
+## User Stories
+
+### US1: Default Ready PR
+
+As a workflow user, I want `node scripts/publish-branch.mjs` to create a ready-for-review PR so that normal feature work immediately enters the repository review flow.
+
+### US2: Intentional Draft PR
+
+As a workflow user, I want `node scripts/publish-branch.mjs --draft` to create a draft PR so that I can explicitly pause review when work is knowingly incomplete.
+
+## Acceptance Criteria
+
+- AC-001: When no draft option is supplied, `scripts/publish-branch.mjs` calls `gh pr create` without `--draft`.
+- AC-002: When `--draft` is supplied, `scripts/publish-branch.mjs` calls `gh pr create` with `--draft`.
+- AC-003: Bootstrap installs the canonical publisher unchanged, so a newly bootstrapped repository receives the same default and explicit-draft behavior.
+- AC-004: Source and installed workflow documentation state the ready-by-default contract and the explicit `--draft` escape hatch.
+
+## Negative Scenarios
+
+- NS-001: A normal publication must not silently create a draft PR.
+- NS-002: An explicit `--draft` invocation must not be ignored.
+- NS-003: The change must not alter unrelated portable workflow, CI, review-gate, or branch-protection behavior.
+- NS-004: The blueprint must remain synthetic and free of secrets, private identifiers, and source-project residue.
+
+## Requirements
+
+- FR-001: Build the `gh pr create` arguments so `--draft` is present only when the parsed `draft` option is truthy.
+- FR-002: Add isolated tests that inspect the effective `gh pr create` arguments for default-ready and explicit-draft runs.
+- FR-003: Add bootstrap coverage proving the installed publisher remains byte-identical to the canonical source.
+- FR-004: Update only documentation that describes PR publication behavior.
+
+## Success Criteria
+
+- SC-001: Both publication-mode tests pass.
+- SC-002: `pnpm run preflight` passes, including sanitizer, baseline, and feature-memory checks.
+- SC-003: The resulting PR is opened ready for review and has green required CI checks before handoff.
+
+## Assumptions
+
+- GitHub CLI creates a ready-for-review PR when `gh pr create` omits `--draft`.
+- Bootstrap continues to copy `scripts/publish-branch.mjs` from the source blueprint without transformations.

--- a/specs/012-ready-pr-publication-default/tasks.md
+++ b/specs/012-ready-pr-publication-default/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Ready PR Publication Default
+
+## Setup
+
+- [x] T001 Refresh `origin/main`, create the isolated `codex/ready-pr-publication` branch, and locate all publisher, bootstrap, test, and documentation references.
+- [x] T002 Create feature memory after the local preflight gate identified it as required for this workflow change.
+
+## Implementation
+
+- [x] T003 Make `--draft` conditional on the explicit publisher option.
+- [x] T004 Update the source and installed workflow documentation for ready-by-default publication.
+- [x] T005 Add publisher mode tests and bootstrap preservation coverage.
+
+## Verification
+
+- [x] T006 Run `pnpm test` and verify both ready and explicit-draft tests pass.
+- [x] T007 Run `pnpm run preflight` after feature memory is complete.
+- [ ] T008 Publish a ready-for-review PR, verify CI and review gates, and hand off without merging.
+
+## Process Memory
+
+### Dead Ends
+
+- The first `pnpm run preflight` was intentionally stopped by the feature-memory gate because the change touched configured product paths before this feature folder existed. The required files were then added rather than bypassing the gate.
+
+### Decisions
+
+- Keep draft support as the existing generic `--draft` flag and make omission the ready-for-review default; no new configuration key or profile switch is needed.
+- Test command construction through synthetic executable shims rather than opening network PRs, so the behavior is deterministic and safe in local verification.
+- Treat the raw script copy performed by bootstrap as the canonical generator path and assert byte identity after installation.
+
+### Known Issues
+
+- None identified. CI and GitHub review evidence remain to be collected after the branch is published.

--- a/templates/README.md
+++ b/templates/README.md
@@ -35,6 +35,9 @@ pnpm run worktree:new -- --slug 001-example
 pnpm run pr:publish
 ```
 
+`pnpm run pr:publish` opens a ready-for-review pull request by default. Use
+`pnpm run pr:publish -- --draft` only when a draft is intentional.
+
 ## Required PR Checks
 
 The active list is `.unicorn-hub/config.json` (`requiredChecks`). The defaults installed by bootstrap reflect the chosen profile; stack-specific profiles that preserve existing target CI ship only Unicorn-controlled contexts (`guard`, `AI Review`) and expect the team to add the repository's real CI job names before applying branch protection.

--- a/templates/docs_project/project/devops/ai-pr-workflow.md
+++ b/templates/docs_project/project/devops/ai-pr-workflow.md
@@ -2,6 +2,9 @@
 
 The active required-check list is `.unicorn-hub/config.json` (`requiredChecks`); installed defaults reflect the active profile. Stack-specific profiles that preserve existing target CI ship only `guard` and `AI Review` and expect the team to add the repository's real CI job names before applying branch protection.
 
+`node scripts/publish-branch.mjs` opens PRs ready for review by default. Pass
+`--draft` only when the author explicitly wants a draft PR.
+
 PRs are merge-ready only when all checks are green, blocking findings are resolved, docs/specs are updated, and no conflicts remain.
 
 `AI Review` is a required check and is event-driven. It fails quickly when a

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -58,6 +58,7 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
     "scripts/ai-review-rerun.mjs",
     "scripts/check-context-budget.mjs",
     "scripts/check-feature-memory.mjs",
+    "scripts/publish-branch.mjs",
     ".unicorn-hub/config.json"
   ]) {
     assert.equal(existsSync(join(target, path)), true, `${path} should exist`);
@@ -103,6 +104,11 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
   const packageJson = JSON.parse(readFileSync(join(target, "package.json"), "utf8"));
   assert.equal(packageJson.scripts["check:context"], "node scripts/check-context-budget.mjs");
   assert.match(packageJson.scripts.preflight, /pnpm run check:context -- --local-preflight && pnpm run check:context -- --worktree/);
+  assert.equal(
+    readFileSync(join(target, "scripts/publish-branch.mjs"), "utf8"),
+    readFileSync(join(root, "scripts/publish-branch.mjs"), "utf8"),
+    "bootstrap must preserve the canonical PR publication behavior"
+  );
 
   const prGuard = readFileSync(join(target, ".github/workflows/pr-guard.yml"), "utf8");
   assert.match(prGuard, /Validate context budget/);

--- a/tests/publish-branch.test.mjs
+++ b/tests/publish-branch.test.mjs
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const root = resolve(".");
+
+function writeExecutable(path, source) {
+  writeFileSync(path, source);
+  chmodSync(path, 0o755);
+}
+
+function publish(args = []) {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-publish-"));
+  const bin = join(target, "bin");
+  const log = join(target, "gh-create-args.json");
+  mkdirSync(bin);
+  mkdirSync(join(target, ".unicorn-hub"));
+  writeFileSync(join(target, ".unicorn-hub/config.json"), '{"defaultBaseBranch":"main"}\n');
+  writeFileSync(join(target, "package.json"), '{"private":true}\n');
+
+  writeExecutable(join(bin, "git"), `#!/bin/sh
+if [ "$1" = "branch" ]; then
+  printf '%s\\n' 'test-ready-pr'
+fi
+`);
+  writeExecutable(join(bin, "pnpm"), "#!/bin/sh\nexit 0\n");
+  writeExecutable(join(bin, "gh"), `#!/bin/sh
+if [ "$1" = "repo" ]; then
+  printf '%s\\n' 'synthetic-owner/synthetic-repo'
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  exit 1
+fi
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  node -e 'require("node:fs").writeFileSync(process.env.GH_CREATE_LOG, JSON.stringify(process.argv.slice(1)))' "$@"
+fi
+`);
+
+  execFileSync("node", [join(root, "scripts/publish-branch.mjs"), ...args], {
+    cwd: target,
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, GH_CREATE_LOG: log },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  return JSON.parse(readFileSync(log, "utf8"));
+}
+
+test("publish-branch creates a ready-for-review PR by default", () => {
+  const args = publish();
+  assert.equal(args.includes("--draft"), false);
+  assert.deepEqual(args.slice(0, 2), ["pr", "create"]);
+});
+
+test("publish-branch creates a draft PR only with --draft", () => {
+  const args = publish(["--draft"]);
+  assert.equal(args.includes("--draft"), true);
+});


### PR DESCRIPTION
## Summary

- Make the canonical publisher create ready-for-review PRs by default.
- Preserve draft PR creation behind an explicit `--draft` option.
- Cover both modes, bootstrap propagation, and workflow documentation.

## Validation

- `pnpm run preflight`

Co-authored-by: Codex <codex@openai.com>