### PR TITLE
feat: add portable dependency install guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.34.5
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -27,16 +29,11 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
-      - name: Install dependencies
-        run: |
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          else
-            pnpm install --no-frozen-lockfile
-          fi
-
       - name: Run repository baseline
         run: pnpm run check:repo
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests if present
         run: pnpm run --if-present test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm run check:repo
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts --ignore-pnpmfile
 
       - name: Run tests if present
         run: pnpm run --if-present test

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -32,6 +32,15 @@ jobs:
           path: .gate-trusted
           fetch-depth: 1
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.34.5
+
+      - name: Setup uv for Python lock verification
+        if: ${{ hashFiles('uv.lock') != '' }}
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
       - name: Resolve diff refs
         shell: bash
         env:
@@ -77,4 +86,13 @@ jobs:
           else
             echo "::warning::Trusted baseline script missing on default branch; using PR script for first-install bootstrap only."
             node scripts/check-repo-baseline.mjs --target "$GITHUB_WORKSPACE"
+          fi
+
+      - name: Enforce dependency policy
+        run: |
+          if [ -f .gate-trusted/scripts/check-dependency-policy.mjs ]; then
+            node .gate-trusted/scripts/check-dependency-policy.mjs --sync-python --target "$GITHUB_WORKSPACE" "$BASE_REF" "$HEAD_REF"
+          else
+            echo "::warning::Trusted dependency policy script missing on default branch; using PR script for first-install bootstrap only."
+            node scripts/check-dependency-policy.mjs --sync-python --target "$GITHUB_WORKSPACE" "$BASE_REF" "$HEAD_REF"
           fi

--- a/.unicorn-hub/config.json
+++ b/.unicorn-hub/config.json
@@ -8,5 +8,17 @@
   "trustedReviewLoginsByAgent": {},
   "defaultImplementationAgent": "claude",
   "defaultReviewAgent": "codex",
+  "dependencyPolicy": {
+    "node": {
+      "minimumReleaseAgeMinutes": 10080,
+      "registryTimeoutMilliseconds": 10000,
+      "protectedPackageNames": [],
+      "typosquatExceptions": []
+    },
+    "python": {
+      "enabled": false,
+      "requirementsLockFile": "requirements.lock"
+    }
+  },
   "blueprint": true
 }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Current profiles include:
 - Agent rules: `AGENTS.md` and `CLAUDE.md`
 - Local orchestration scripts for worktrees, PR publishing, feature-memory gates, context budget checks, AI review gates, and branch protection
 - GitHub Actions workflows for CI, PR guard, trusted AI review routing, and OSV scanning
-- Supply-chain defaults: pnpm `minimumReleaseAge`, Dependabot cooldown, pinned package manager, lockfile-oriented installs
+- Supply-chain defaults: strict frozen pnpm locks, release-age and provenance policy, exact-version install-script allowlisting, a lightweight direct-dependency/typosquat guard, profile-scoped locked Python installs, Dependabot cooldown, and a pinned package manager
 - A `.gitattributes` block that marks the installed governance envelope (the managed script files bootstrap writes or recognizes as unchanged blueprint copies, `.unicorn-hub/**`, and `.specify/**`) as `linguist-vendored`, so the blueprint's Node scaffolding does not skew the target repo's GitHub language bar. Bootstrap appends this block idempotently and never overwrites an existing consumer `.gitattributes`; pre-existing consumer script collisions and product code keep their language stats.
 
 ## Canonical Workflow

--- a/docs/bootstrap-flow.md
+++ b/docs/bootstrap-flow.md
@@ -59,6 +59,7 @@ Install scripts for:
 
 - one worktree per task
 - feature-memory enforcement
+- direct-dependency, lockfile, registry, typosquat, and install-script policy enforcement
 - repository baseline verification
 - context budget and agent-readiness reporting
 - PR publishing
@@ -80,6 +81,17 @@ Install workflows:
 When a target repository already has a mature CI workflow, do not overwrite it. Keep the existing workflow, install the additional guard/review/security workflows, and set `.unicorn-hub/config.json` `requiredChecks` to the target's real CI job names plus the Unicorn guard and review jobs.
 
 Profiles can declare `excludeTemplates` to skip blueprint templates that conflict with the target stack. The `flutter-app` profile excludes the default Node `ci.yml`, so fresh Flutter targets are not handed a `baseline-checks` workflow that would never match their CI. `excludeTemplates` is enforced even under `--force`; the flag only refreshes templates the profile considers compatible.
+
+Bootstrap also installs `pnpm-workspace.yaml`, a minimal `pnpm-lock.yaml`, and
+`scripts/check-dependency-policy.mjs`. Existing consumer copies are preserved by
+default; `--force` is the explicit refresh contract. A generated minimal lock is
+safe only while the generated package manifest has no dependencies. If an
+existing target manifest declares dependencies, generate and review a matching
+lock before CI—the guard intentionally fails closed instead of repairing it.
+
+The generated `.unicorn-hub/config.json` carries dependency-policy settings and
+version-scoped exception records. Python lock enforcement is enabled for the
+`python-service` and `telegram-bot` profiles and disabled for unrelated profiles.
 
 Set repository variables:
 

--- a/docs/github-ci-and-branch-protection.md
+++ b/docs/github-ci-and-branch-protection.md
@@ -11,7 +11,7 @@ request in draft state.
 ## Required Workflows
 
 - `ci.yml`: runs repository baseline checks as `baseline-checks`, unless a stack-specific profile preserves an existing target CI workflow
-- `pr-guard.yml`: enforces feature-memory, context-budget, and baseline coverage as `guard`
+- `pr-guard.yml`: enforces feature-memory, context-budget, baseline, frozen-lock, registry identity/age, lightweight typosquat, install-script, and profile-scoped Python lock policy as `guard`
 - `ai-command-policy.yml`: validates trusted AI command comments
 - `ai-review.yml`: normalizes native review output into a required `AI Review` check
 - `ai-review-rerun.yml`: reruns `AI Review` when trusted review evidence appears
@@ -29,6 +29,9 @@ For existing repositories, `requiredChecks` comes from `.unicorn-hub/config.json
 - Gate scripts must run from the trusted default branch, not PR-supplied code.
 - Context-budget gates must run against the committed PR diff, not only the local worktree, so placeholder-only specs cannot pass after they are committed.
 - Skipped required gates must not be used as a successful state.
+- Node installation never falls back from `pnpm install --frozen-lockfile`; a missing or stale lockfile fails.
+- Changed direct dependencies fail when official-registry identity, exact version, publication time, source policy, or required install-script approval cannot be proven.
+- Registry outages produce a blocking “not verified” result rather than an advisory pass.
 
 ## Branch Protection Baseline
 

--- a/docs/github-ci-and-branch-protection.md
+++ b/docs/github-ci-and-branch-protection.md
@@ -29,7 +29,7 @@ For existing repositories, `requiredChecks` comes from `.unicorn-hub/config.json
 - Gate scripts must run from the trusted default branch, not PR-supplied code.
 - Context-budget gates must run against the committed PR diff, not only the local worktree, so placeholder-only specs cannot pass after they are committed.
 - Skipped required gates must not be used as a successful state.
-- Node installation never falls back from `pnpm install --frozen-lockfile`; a missing or stale lockfile fails.
+- Node installation never falls back from a frozen lockfile; PR CI also passes `--ignore-scripts --ignore-pnpmfile`, and a missing or stale lockfile fails.
 - Changed direct dependencies fail when official-registry identity, exact version, publication time, source policy, or required install-script approval cannot be proven.
 - Registry outages produce a blocking “not verified” result rather than an advisory pass.
 

--- a/docs/local-preflight.md
+++ b/docs/local-preflight.md
@@ -22,6 +22,16 @@ It should run, at minimum:
 - tests
 - sanitizer for blueprint/template repositories
 
+Dependency-policy checks are available as:
+
+```bash
+pnpm run check:dependencies -- <base-ref> <head-ref>
+```
+
+The GitHub PR Guard supplies immutable base/head SHAs. The checker validates the
+workspace policy and frozen lock even when no direct dependency changed; remote
+registry calls are limited to new or changed direct dependencies.
+
 Profiles may override the installed control-plane `preflight` script to call target-native checks after Unicorn gates. For example, a Flutter target can keep its existing `make check` and `make test` workflow while still running repository baseline, context budget, and feature-memory validation first.
 
 The local preflight context check validates committed changes against

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -122,6 +122,13 @@ uv lock --check
 uv sync --locked
 ```
 
+The trusted PR Guard validates the lock with `uv lock --check --no-build`, then
+installs only locked dependencies with
+`uv sync --locked --no-install-project --no-build`. It does not build or install
+the PR-controlled project, so a local PEP 517 backend cannot execute inside the
+guard. The profile's ordinary development install remains `uv sync --locked`
+so the project itself is available outside that trusted verification boundary.
+
 If `uv.lock` is not used, the compatible contract is a fully pinned
 `requirements.lock` where every direct and transitive requirement has a
 `sha256` hash, installed with pip's official [hash-checking mode](https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode) and binary-only policy:

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -8,7 +8,7 @@ Use a pinned package manager:
 
 ```json
 {
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@10.34.5"
 }
 ```
 
@@ -23,6 +23,115 @@ minimumReleaseAge: 10080
 ```
 
 That is seven days in minutes. It prevents freshly published packages from being installed immediately after release.
+
+## pnpm Install Policy
+
+Both the blueprint and installed workspace template use pnpm 10.34.5 or newer,
+which includes the upstream
+[request-routing fixes](https://github.com/pnpm/pnpm/security/advisories/GHSA-vx52-2968-3vc6), and
+set the following dependency-build policy:
+
+```yaml
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+strictDepBuilds: true
+allowBuilds: {}
+```
+
+`blockExoticSubdeps` rejects exotic transitive sources, `trustPolicy` prevents a
+provenance downgrade, and `strictDepBuilds` makes an unreviewed dependency build
+script fail the install. Do not enable `dangerouslyAllowAllBuilds` or fall back
+to a global lifecycle-script allowance. Add only exact package versions that
+genuinely require installation scripts:
+
+```yaml
+allowBuilds:
+  "synthetic-native-addon@1.2.3": true
+```
+
+The exact-version entry is deliberately visible in review. pnpm documents these
+controls in its official [settings reference](https://pnpm.io/settings).
+
+## Frozen Node Installs
+
+`pnpm-lock.yaml` is mandatory. CI runs only:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+There is no `--no-frozen-lockfile` fallback. A missing lockfile or a manifest
+that no longer matches it fails both CI and the dependency-policy guard.
+
+## Direct Dependency Policy
+
+`scripts/check-dependency-policy.mjs` runs inside the existing `guard` job. It
+examines only direct dependency declarations added or changed between the PR
+base and head, then:
+
+- accepts registry ranges only when the committed pnpm lock resolves one exact version
+- rejects Git, URL, tarball, archive, alias, and local dependency sources
+- rejects npm registry overrides other than the official npm registry
+- verifies the exact package name, version, and publication time with the official registry
+- fails closed with a “not verified” diagnostic when registry evidence is unavailable
+- detects non-ASCII/Unicode substitutions and one-edit or adjacent-transposition similarities against a deliberately small protected-name set
+- requires exact-version `allowBuilds` approval when registry metadata declares an install lifecycle script
+
+The checker has no popularity database and does not attempt to score package
+reputation. Extra names can be protected through
+`.unicorn-hub/config.json` (`dependencyPolicy.node.protectedPackageNames`). A
+suspicious name can proceed only through a version-scoped exception with a
+non-empty reason in the same reviewed configuration:
+
+```json
+{
+  "dependencyPolicy": {
+    "node": {
+      "typosquatExceptions": [
+        {
+          "package": "synthetic-reviewed-name",
+          "version": "1.2.3",
+          "reason": "Reviewed against the upstream publisher and release record."
+        }
+      ]
+    }
+  }
+}
+```
+
+Before invoking pnpm, the guard also rejects request-routing overrides,
+non-official lockfile artifact sources, pnpm policy escape hatches, and YAML
+indirection that its deliberately small parser cannot interpret safely. These
+are repository-wide installation-boundary checks; remote metadata requests
+remain limited to new or changed direct dependencies and newly granted
+`allowBuilds` entries.
+
+## Locked Python Installs
+
+Python rules are enabled by the `python-service` and `telegram-bot` profiles, or
+explicitly with `dependencyPolicy.python.enabled`. Other profiles are not
+forced to carry Python lock artifacts.
+
+The preferred contract follows the official [uv lock and sync behavior](https://docs.astral.sh/uv/concepts/projects/sync/):
+
+```bash
+uv lock --check
+uv sync --locked
+```
+
+If `uv.lock` is not used, the compatible contract is a fully pinned
+`requirements.lock` where every direct and transitive requirement has a
+`sha256` hash, installed with pip's official [hash-checking mode](https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode) and binary-only policy:
+
+```bash
+python -m pip --isolated install --index-url https://pypi.org/simple --require-hashes --only-binary :all: -r requirements.lock
+```
+
+An unpinned `requirements.txt`, a missing hash, a source distribution, a VCS or
+local requirement, or an unknown package index is not a safe installation mode.
+The PR Guard validates the selected lock contract before performing the locked
+sync in the same `guard` job.
 
 ## Dependabot Cooldown and Grouping
 

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -126,8 +126,11 @@ The trusted PR Guard validates the lock with `uv lock --check --no-build`, then
 installs only locked dependencies with
 `uv sync --locked --no-install-project --no-build`. It does not build or install
 the PR-controlled project, so a local PEP 517 backend cannot execute inside the
-guard. The profile's ordinary development install remains `uv sync --locked`
-so the project itself is available outside that trusted verification boundary.
+guard. Before either command, every locked registry must match the official
+PyPI index and every locked wheel or source artifact URL must use the exact
+`https://files.pythonhosted.org/packages/` distribution host. The profile's
+ordinary development install remains `uv sync --locked` so the project itself
+is available outside that trusted verification boundary.
 
 If `uv.lock` is not used, the compatible contract is a fully pinned
 `requirements.lock` where every direct and transitive requirement has a

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -58,11 +58,15 @@ controls in its official [settings reference](https://pnpm.io/settings).
 `pnpm-lock.yaml` is mandatory. CI runs only:
 
 ```bash
-pnpm install --frozen-lockfile
+pnpm install --frozen-lockfile --ignore-scripts --ignore-pnpmfile
 ```
 
 There is no `--no-frozen-lockfile` fallback. A missing lockfile or a manifest
-that no longer matches it fails both CI and the dependency-policy guard.
+that no longer matches it fails both CI and the dependency-policy guard. Pull
+request CI also disables lifecycle scripts and pnpmfile hooks, so dependency
+code cannot execute before the separate trusted policy workflow approves the
+current dependency graph. Exact-version `allowBuilds` entries remain explicit
+review evidence for trusted post-merge or deployment installs.
 
 ## Direct Dependency Policy
 

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -105,9 +105,14 @@ non-official lockfile artifact sources, pnpm policy escape hatches, and YAML
 indirection that its deliberately small parser cannot interpret safely. It also
 rejects repository `.pnpmfile.cjs`/`.pnpmfile.mjs` hooks and custom `pnpmfile`
 or `global-pnpmfile` settings, because those hooks can rewrite manifests during
-the real frozen install. These are repository-wide installation-boundary
-checks; remote metadata requests remain limited to new or changed direct
-dependencies and newly granted `allowBuilds` entries.
+the real frozen install. pnpm graph-rewrite settings (`overrides`,
+`packageExtensions`, and `patchedDependencies`) are likewise rejected in both
+`pnpm-workspace.yaml` and package-manifest `pnpm` objects; otherwise a lock-only
+change could inject dependencies outside direct-declaration verification.
+Package-manifest `pnpm` objects also cannot override the enforced build,
+release-age, provenance, or hook policy. These are repository-wide
+installation-boundary checks; remote metadata requests remain limited to new
+or changed direct dependencies and newly granted `allowBuilds` entries.
 
 ## Locked Python Installs
 

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -102,10 +102,12 @@ non-empty reason in the same reviewed configuration:
 
 Before invoking pnpm, the guard also rejects request-routing overrides,
 non-official lockfile artifact sources, pnpm policy escape hatches, and YAML
-indirection that its deliberately small parser cannot interpret safely. These
-are repository-wide installation-boundary checks; remote metadata requests
-remain limited to new or changed direct dependencies and newly granted
-`allowBuilds` entries.
+indirection that its deliberately small parser cannot interpret safely. It also
+rejects repository `.pnpmfile.cjs`/`.pnpmfile.mjs` hooks and custom `pnpmfile`
+or `global-pnpmfile` settings, because those hooks can rewrite manifests during
+the real frozen install. These are repository-wide installation-boundary
+checks; remote metadata requests remain limited to new or changed direct
+dependencies and newly granted `allowBuilds` entries.
 
 ## Locked Python Installs
 

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "private": true,
   "description": "Portable multi-agent development blueprint.",
   "type": "module",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.34.5",
   "engines": {
     "node": ">=20",
-    "pnpm": ">=10.16"
+    "pnpm": ">=10.34.5"
   },
   "scripts": {
     "bootstrap": "node scripts/bootstrap-repo.mjs",
     "agent:set": "node scripts/set-implementation-agent.mjs",
     "check:context": "node scripts/check-context-budget.mjs",
+    "check:dependencies": "node scripts/check-dependency-policy.mjs",
     "check:feature-memory": "node scripts/check-feature-memory.mjs",
     "check:repo": "node scripts/check-repo-baseline.mjs",
     "check:syntax": "node scripts/preflight.mjs --syntax-only",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 minimumReleaseAge: 10080
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+strictDepBuilds: true
+allowBuilds: {}
 packages:
   - .

--- a/profiles/python-service.json
+++ b/profiles/python-service.json
@@ -4,12 +4,18 @@
   "docsDir": "docs_project",
   "specsDir": "specs",
   "productPaths": ["src/", "app/", "service/", "scripts/", "pyproject.toml", "requirements.txt", "requirements-dev.txt"],
-  "packageManager": "project-specific",
+  "packageManager": "uv",
   "pythonVersion": "3.12",
   "commands": {
-    "install": "python -m pip install -r requirements-dev.txt",
-    "test": "python -m pytest",
-    "preflight": "python -m pytest"
+    "install": "uv lock --check && uv sync --locked",
+    "test": "uv run pytest",
+    "preflight": "uv lock --check && uv run pytest"
+  },
+  "dependencyPolicy": {
+    "python": {
+      "enabled": true,
+      "requirementsLockFile": "requirements.lock"
+    }
   },
   "requiredChecks": ["baseline-checks", "guard", "AI Review"],
   "deploy": {

--- a/profiles/telegram-bot.json
+++ b/profiles/telegram-bot.json
@@ -7,9 +7,18 @@
   "architecture": {
     "rule": "Each command or conversation flow should be implemented as an isolated handler with injected ports for external services."
   },
+  "packageManager": "uv",
+  "pythonVersion": "3.12",
   "commands": {
-    "test": "npm test",
-    "preflight": "pnpm run preflight"
+    "install": "uv lock --check && uv sync --locked",
+    "test": "uv run pytest",
+    "preflight": "uv lock --check && uv run pytest"
+  },
+  "dependencyPolicy": {
+    "python": {
+      "enabled": true,
+      "requirementsLockFile": "requirements.lock"
+    }
   },
   "requiredChecks": ["baseline-checks", "guard", "AI Review"],
   "deploy": {

--- a/scripts/bootstrap-repo.mjs
+++ b/scripts/bootstrap-repo.mjs
@@ -192,6 +192,7 @@ for (const rel of walkFiles(join(sourceRoot, "templates"))) {
 
 const scriptAllowlist = new Set([
   "shared.mjs",
+  "check-dependency-policy.mjs",
   "check-context-budget.mjs",
   "check-feature-memory.mjs",
   "check-repo-baseline.mjs",
@@ -235,6 +236,18 @@ const config = {
   trustedReviewLoginsByAgent: {},
   profile: profile.id,
   commands: profile.commands || {},
+  dependencyPolicy: {
+    node: {
+      minimumReleaseAgeMinutes: 10080,
+      registryTimeoutMilliseconds: 10000,
+      protectedPackageNames: [],
+      typosquatExceptions: []
+    },
+    python: {
+      enabled: Boolean(profile.dependencyPolicy?.python?.enabled),
+      requirementsLockFile: profile.dependencyPolicy?.python?.requirementsLockFile || "requirements.lock"
+    }
+  },
   excludeTemplates: Array.isArray(profile.excludeTemplates) ? [...profile.excludeTemplates] : []
 };
 

--- a/scripts/check-dependency-policy.mjs
+++ b/scripts/check-dependency-policy.mjs
@@ -16,6 +16,25 @@ const DEPENDENCY_FIELDS = [
   "peerDependencies"
 ];
 const INSTALL_SCRIPT_NAMES = ["preinstall", "install", "postinstall"];
+const PNPM_GRAPH_REWRITE_KEYS = ["overrides", "packageExtensions", "patchedDependencies"];
+const PNPM_MANIFEST_OVERRIDE_KEYS = [
+  ...PNPM_GRAPH_REWRITE_KEYS,
+  "dangerouslyAllowAllBuilds",
+  "allowBuilds",
+  "onlyBuiltDependencies",
+  "onlyBuiltDependenciesFile",
+  "ignoredBuiltDependencies",
+  "neverBuiltDependencies",
+  "strictDepBuilds",
+  "blockExoticSubdeps",
+  "minimumReleaseAge",
+  "minimumReleaseAgeExclude",
+  "trustPolicy",
+  "trustPolicyExclude",
+  "trustPolicyIgnoreAfter",
+  "pnpmfile",
+  "globalPnpmfile"
+];
 
 // This deliberately small set protects common high-value spellings without
 // turning the blueprint into a package popularity or reputation database.
@@ -183,7 +202,8 @@ export function validateWorkspacePolicy(text, minimumReleaseAgeMinutes = 10080) 
     "pnprServer",
     "namedRegistries",
     "pnpmfile",
-    "globalPnpmfile"
+    "globalPnpmfile",
+    ...PNPM_GRAPH_REWRITE_KEYS
   ];
   for (const key of forbiddenKeys) {
     if (uncommented.some((line) => new RegExp(`^${key}:`).test(line))) {
@@ -502,7 +522,8 @@ export function parseNpmrc(text) {
       "minimumreleaseageexclude",
       "trustpolicy",
       "trustpolicyexclude",
-      "trustpolicyignoreafter"
+      "trustpolicyignoreafter",
+      ...PNPM_GRAPH_REWRITE_KEYS.map((setting) => setting.toLowerCase())
     ].includes(normalizedKey)) {
       registries.unsafePolicySettings.push(key);
     }
@@ -513,6 +534,14 @@ export function parseNpmrc(text) {
     else registries.default = value;
   }
   return registries;
+}
+
+export function validatePackageManifestPolicy(manifest) {
+  const pnpmSettings = manifest?.pnpm;
+  if (!pnpmSettings || typeof pnpmSettings !== "object" || Array.isArray(pnpmSettings)) return [];
+  return PNPM_MANIFEST_OVERRIDE_KEYS
+    .filter((key) => Object.hasOwn(pnpmSettings, key))
+    .map((key) => `package.json pnpm.${key} is not supported by the portable dependency policy`);
 }
 
 function registryForPackage(name, npmrc) {
@@ -910,8 +939,17 @@ export async function runDependencyPolicy({
       baseManifestPaths = manifestPathsAtRef(root, baseRef);
       headManifestPaths = manifestPathsAtRef(root, headRef);
       for (const manifestPath of headManifestPaths) {
-        if (!repositoryRegularFile(root, manifestPath)) {
+        const localManifestPath = repositoryRegularFile(root, manifestPath);
+        if (!localManifestPath) {
           errors.push(`package manifest '${manifestPath}' must be a regular, non-symlink repository file`);
+          continue;
+        }
+        try {
+          const manifest = JSON.parse(readFileSync(localManifestPath, "utf8"));
+          errors.push(...validatePackageManifestPolicy(manifest)
+            .map((error) => `${manifestPath}: ${error}`));
+        } catch {
+          errors.push(`package manifest '${manifestPath}' must contain valid JSON`);
         }
       }
     } catch {

--- a/scripts/check-dependency-policy.mjs
+++ b/scripts/check-dependency-policy.mjs
@@ -95,6 +95,17 @@ function repositoryRegularFile(root, value) {
   }
 }
 
+function repositoryEntryExists(root, value) {
+  const path = repositoryPath(root, value);
+  if (!path) return false;
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function yamlScalar(value) {
   const trimmed = String(value).trim();
   if ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
@@ -169,7 +180,9 @@ export function validateWorkspacePolicy(text, minimumReleaseAgeMinutes = 10080) 
     "noProxy",
     "noproxy",
     "pnprServer",
-    "namedRegistries"
+    "namedRegistries",
+    "pnpmfile",
+    "globalPnpmfile"
   ];
   for (const key of forbiddenKeys) {
     if (uncommented.some((line) => new RegExp(`^${key}:`).test(line))) {
@@ -461,7 +474,8 @@ export function parseNpmrc(text) {
     default: OFFICIAL_NPM_REGISTRY,
     scopes: new Map(),
     unsafeSettings: [],
-    unsafePolicySettings: []
+    unsafePolicySettings: [],
+    unsafeHookSettings: []
   };
   for (const rawLine of String(text).split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -471,6 +485,9 @@ export function parseNpmrc(text) {
       registries.unsafeSettings.push(key);
     }
     const normalizedKey = key.replace(/[-_.\[\]]/g, "");
+    if (["pnpmfile", "globalpnpmfile"].includes(normalizedKey)) {
+      registries.unsafeHookSettings.push(key);
+    }
     if ([
       "dangerouslyallowallbuilds",
       "allowbuilds",
@@ -860,6 +877,14 @@ export async function runDependencyPolicy({
   }
   for (const setting of npmrc.unsafePolicySettings) {
     errors.push(`project .npmrc dependency-policy override '${setting}' is not supported`);
+  }
+  for (const setting of npmrc.unsafeHookSettings) {
+    errors.push(`project .npmrc pnpm hook setting '${setting}' is not supported`);
+  }
+  for (const hookFile of [".pnpmfile.cjs", ".pnpmfile.mjs"]) {
+    if (repositoryEntryExists(root, hookFile)) {
+      errors.push(`${hookFile} is not supported; repository-controlled pnpm hooks must be absent`);
+    }
   }
   let baseManifestPaths = [];
   let headManifestPaths = [];

--- a/scripts/check-dependency-policy.mjs
+++ b/scripts/check-dependency-policy.mjs
@@ -671,7 +671,7 @@ export function validatePythonContract(root, config, runCommand = execFileSync) 
     errors.push(...uvIndexErrors(root, allowedIndexes));
     if (errors.length > 0) return errors;
     try {
-      runCommand("uv", ["lock", "--check"], {
+      runCommand("uv", ["lock", "--check", "--no-build"], {
         cwd: root,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"]
@@ -711,7 +711,10 @@ export function syncPythonContract(root, config, runCommand = execFileSync) {
       if (!repositoryRegularFile(root, "uv.lock") || !repositoryRegularFile(root, "pyproject.toml")) {
         return ["uv.lock and pyproject.toml must be regular, non-symlink repository files"];
       }
-      runCommand("uv", ["sync", "--locked"], { cwd: root, stdio: "inherit" });
+      runCommand("uv", ["sync", "--locked", "--no-install-project", "--no-build"], {
+        cwd: root,
+        stdio: "inherit"
+      });
     } else {
       const lockFile = String(pythonPolicy.requirementsLockFile || "requirements.lock");
       if (!repositoryRegularFile(root, lockFile)) {

--- a/scripts/check-dependency-policy.mjs
+++ b/scripts/check-dependency-policy.mjs
@@ -1,0 +1,996 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, sep, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { findRepoRoot, parseArgs, readConfig } from "./shared.mjs";
+
+const OFFICIAL_NPM_REGISTRY = "https://registry.npmjs.org/";
+const OFFICIAL_PYTHON_INDEX = "https://pypi.org/simple";
+const PYTHON_PROFILES = new Set(["python-service", "telegram-bot"]);
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies"
+];
+const INSTALL_SCRIPT_NAMES = ["preinstall", "install", "postinstall"];
+
+// This deliberately small set protects common high-value spellings without
+// turning the blueprint into a package popularity or reputation database.
+export const DEFAULT_PROTECTED_PACKAGE_NAMES = Object.freeze([
+  "axios",
+  "eslint",
+  "express",
+  "jest",
+  "lodash",
+  "next",
+  "prettier",
+  "react",
+  "react-dom",
+  "typescript",
+  "vite",
+  "webpack"
+]);
+
+const CONFUSABLES = new Map(Object.entries({
+  "а": "a", "Α": "a", "α": "a",
+  "с": "c", "ϲ": "c",
+  "е": "e", "Ε": "e", "ε": "e",
+  "і": "i", "Ι": "i", "ι": "i",
+  "ј": "j",
+  "о": "o", "Ο": "o", "ο": "o",
+  "р": "p", "Ρ": "p", "ρ": "p",
+  "ѕ": "s",
+  "х": "x", "Χ": "x", "χ": "x",
+  "у": "y", "Υ": "y",
+  "κ": "k", "ν": "v", "τ": "t"
+}));
+
+function normalizeUrl(value) {
+  try {
+    const url = new URL(String(value));
+    url.hash = "";
+    url.search = "";
+    return url.href.replace(/\/+$/, "/");
+  } catch {
+    return "";
+  }
+}
+
+function configuredMinimumReleaseAge(nodePolicy) {
+  const value = Number(nodePolicy.minimumReleaseAgeMinutes ?? 10080);
+  return Number.isSafeInteger(value) && value >= 10080 ? value : 10080;
+}
+
+function configuredRegistryTimeout(nodePolicy) {
+  const value = Number(nodePolicy.registryTimeoutMilliseconds ?? 10000);
+  if (!Number.isSafeInteger(value)) return 10000;
+  return Math.min(30000, Math.max(1000, value));
+}
+
+function repositoryPath(root, value) {
+  const candidate = String(value || "");
+  if (!candidate || isAbsolute(candidate)) return null;
+  const resolvedRoot = resolve(root);
+  const resolvedPath = resolve(resolvedRoot, candidate);
+  if (resolvedPath === resolvedRoot || !resolvedPath.startsWith(`${resolvedRoot}${sep}`)) return null;
+  return resolvedPath;
+}
+
+function repositoryRegularFile(root, value) {
+  const candidate = String(value || "").replaceAll("\\", "/");
+  const path = repositoryPath(root, candidate);
+  if (!path || candidate === ".git" || candidate.startsWith(".git/") ||
+      candidate === ".gate-trusted" || candidate.startsWith(".gate-trusted/")) return null;
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) return null;
+    const realRoot = realpathSync(root);
+    const realPath = realpathSync(path);
+    if (realPath !== resolve(realRoot, candidate)) return null;
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+function yamlScalar(value) {
+  const trimmed = String(value).trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1).replaceAll("''", "'");
+  }
+  return trimmed;
+}
+
+export function parseWorkspacePolicy(text) {
+  const result = { allowBuilds: new Map() };
+  const lines = String(text).split(/\r?\n/);
+  let inAllowBuilds = false;
+
+  for (const line of lines) {
+    if (/^allowBuilds:\s*\{\s*\}\s*(?:#.*)?$/.test(line)) {
+      inAllowBuilds = false;
+      result.allowBuildsDeclared = true;
+      continue;
+    }
+    if (/^allowBuilds:\s*(?:#.*)?$/.test(line)) {
+      inAllowBuilds = true;
+      result.allowBuildsDeclared = true;
+      continue;
+    }
+    if (inAllowBuilds) {
+      const entry = line.match(/^ {2}(\S.+?):\s*(true|false)\s*(?:#.*)?$/);
+      if (entry) {
+        result.allowBuilds.set(yamlScalar(entry[1]), entry[2] === "true");
+        continue;
+      }
+      if (/^\S/.test(line) && line.trim()) inAllowBuilds = false;
+    }
+
+    const scalar = line.match(/^([A-Za-z][A-Za-z0-9]*):\s*([^#]*?)\s*(?:#.*)?$/);
+    if (!scalar) continue;
+    const [, key, rawValue] = scalar;
+    const value = yamlScalar(rawValue);
+    if (value === "true" || value === "false") result[key] = value === "true";
+    else if (/^\d+$/.test(value)) result[key] = Number(value);
+    else result[key] = value;
+  }
+  return result;
+}
+
+export function validateWorkspacePolicy(text, minimumReleaseAgeMinutes = 10080) {
+  const lines = String(text).split(/\r?\n/);
+  const uncommented = lines.map((line) => line.replace(/(^|\s)#.*$/, "$1").trimEnd());
+  const policy = parseWorkspacePolicy(text);
+  const errors = [];
+  if (uncommented.some((line) => /^\S/.test(line) && line.trim() &&
+      !/^[A-Za-z][A-Za-z0-9]*:/.test(line))) {
+    errors.push("top-level workspace keys must use canonical unquoted mapping syntax");
+  }
+  if (uncommented.some((line) => /^\s*<<\s*:/.test(line))) {
+    errors.push("YAML merge keys are not supported in security policy");
+  }
+  if (uncommented.some((line) => /!!/.test(line))) {
+    errors.push("explicit YAML type tags are not supported in security policy");
+  }
+  const forbiddenKeys = [
+    "minimumReleaseAgeExclude",
+    "trustPolicyExclude",
+    "trustPolicyIgnoreAfter",
+    "onlyBuiltDependencies",
+    "onlyBuiltDependenciesFile",
+    "ignoredBuiltDependencies",
+    "neverBuiltDependencies",
+    "httpProxy",
+    "httpsProxy",
+    "proxy",
+    "noProxy",
+    "noproxy",
+    "pnprServer",
+    "namedRegistries"
+  ];
+  for (const key of forbiddenKeys) {
+    if (uncommented.some((line) => new RegExp(`^${key}:`).test(line))) {
+      errors.push(`${key} is not supported by the portable dependency policy`);
+    }
+  }
+  if (uncommented.some((line) => /^registries:/.test(line))) {
+    errors.push("workspace registries are not supported; use the official npm registry");
+  }
+  const registryLines = uncommented.filter((line) => /^registry:/.test(line));
+  if (registryLines.length > 1 || registryLines.some((line) =>
+    normalizeUrl(yamlScalar(line.slice(line.indexOf(":") + 1))) !== normalizeUrl(OFFICIAL_NPM_REGISTRY))) {
+    errors.push("workspace registry must be the official npm registry");
+  }
+  const allowBuildDeclarations = uncommented.filter((line) => /^allowBuilds:/.test(line));
+  if (allowBuildDeclarations.length !== 1) errors.push("allowBuilds must be declared exactly once");
+  for (const key of ["minimumReleaseAge", "blockExoticSubdeps", "trustPolicy", "strictDepBuilds"]) {
+    if (uncommented.filter((line) => new RegExp(`^${key}:`).test(line)).length !== 1) {
+      errors.push(`${key} must be declared exactly once`);
+    }
+  }
+  const globalBuildLines = uncommented.filter((line) => /^dangerouslyAllowAllBuilds:/.test(line));
+  if (globalBuildLines.some((line) => line.trim() !== "dangerouslyAllowAllBuilds: false")) {
+    errors.push("dangerouslyAllowAllBuilds must be canonical false when declared");
+  }
+  let inAllowBuilds = false;
+  for (const line of uncommented) {
+    if (/^allowBuilds:\s*\{\s*\}\s*$/.test(line)) {
+      inAllowBuilds = false;
+      continue;
+    }
+    if (/^allowBuilds:\s*$/.test(line)) {
+      inAllowBuilds = true;
+      continue;
+    }
+    if (!inAllowBuilds || !line.trim()) continue;
+    if (/^\S/.test(line)) {
+      inAllowBuilds = false;
+      continue;
+    }
+    if (!/^ {2}\S.+?:\s*(?:true|false)\s*$/.test(line)) {
+      errors.push("allowBuilds entries must use canonical true/false scalars without YAML indirection");
+    }
+  }
+  if (!Number.isFinite(policy.minimumReleaseAge) || policy.minimumReleaseAge < minimumReleaseAgeMinutes) {
+    errors.push(`minimumReleaseAge must be at least ${minimumReleaseAgeMinutes} minutes`);
+  }
+  if (policy.blockExoticSubdeps !== true) errors.push("blockExoticSubdeps must be true");
+  if (policy.trustPolicy !== "no-downgrade") errors.push("trustPolicy must be no-downgrade");
+  if (policy.strictDepBuilds !== true) errors.push("strictDepBuilds must be true");
+  if (!policy.allowBuildsDeclared) errors.push("allowBuilds must be declared explicitly");
+  for (const [matcher, allowed] of policy.allowBuilds) {
+    if (allowed && !isVersionScopedMatcher(matcher)) {
+      errors.push(`allowBuilds entry '${matcher}' must include an exact version`);
+    }
+  }
+  return { policy, errors };
+}
+
+function isVersionScopedMatcher(matcher) {
+  const value = String(matcher);
+  const separator = value.lastIndexOf("@");
+  if (separator <= 0) return false;
+  return isExactVersion(value.slice(separator + 1));
+}
+
+function splitVersionScopedMatcher(matcher) {
+  const value = String(matcher);
+  const separator = value.lastIndexOf("@");
+  if (separator <= 0 || !isExactVersion(value.slice(separator + 1))) return null;
+  return { name: value.slice(0, separator), version: value.slice(separator + 1).replace(/^v/, "") };
+}
+
+export function isExactVersion(value) {
+  return /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(String(value));
+}
+
+export function classifyDependencySpecifier(specifier) {
+  const value = String(specifier).trim();
+  if (!value) return { allowed: false, reason: "empty dependency specifier" };
+  if (/^(?:git(?:\+|:)|github:|gitlab:|bitbucket:|https?:|file:|link:|workspace:|portal:|patch:|path:|npm:)/i.test(value)) {
+    return { allowed: false, reason: "Git, URL, alias, or local dependency sources are forbidden" };
+  }
+  if (/^(?:\.{1,2}\/|~\/|\/)/.test(value)) {
+    return { allowed: false, reason: "local dependency paths are forbidden" };
+  }
+  if (/\.(?:tgz|tar|tar\.gz|zip|gz)(?:[#?].*)?$/i.test(value)) {
+    return { allowed: false, reason: "tarball and archive dependency sources are forbidden" };
+  }
+  if (!/^[0-9A-Za-z*^~<>=|.\-+\s]+$/.test(value)) {
+    return { allowed: false, reason: "dependency specifier is not a supported registry range or tag" };
+  }
+  return { allowed: true };
+}
+
+function packageScope(name) {
+  const match = String(name).match(/^(@[^/]+)\/(.+)$/);
+  return match ? { scope: match[1], leaf: match[2] } : { scope: "", leaf: String(name) };
+}
+
+export function confusableSkeleton(value) {
+  return String(value)
+    .normalize("NFKC")
+    .split("")
+    .map((character) => CONFUSABLES.get(character) || character)
+    .join("")
+    .toLowerCase();
+}
+
+export function damerauLevenshtein(left, right) {
+  const a = [...String(left)];
+  const b = [...String(right)];
+  const matrix = Array.from({ length: a.length + 1 }, () => Array(b.length + 1).fill(0));
+  for (let index = 0; index <= a.length; index += 1) matrix[index][0] = index;
+  for (let index = 0; index <= b.length; index += 1) matrix[0][index] = index;
+  for (let row = 1; row <= a.length; row += 1) {
+    for (let column = 1; column <= b.length; column += 1) {
+      const cost = a[row - 1] === b[column - 1] ? 0 : 1;
+      matrix[row][column] = Math.min(
+        matrix[row - 1][column] + 1,
+        matrix[row][column - 1] + 1,
+        matrix[row - 1][column - 1] + cost
+      );
+      if (row > 1 && column > 1 && a[row - 1] === b[column - 2] && a[row - 2] === b[column - 1]) {
+        matrix[row][column] = Math.min(matrix[row][column], matrix[row - 2][column - 2] + 1);
+      }
+    }
+  }
+  return matrix[a.length][b.length];
+}
+
+export function findSuspiciousName(name, protectedNames = DEFAULT_PROTECTED_PACKAGE_NAMES) {
+  const raw = String(name);
+  const skeleton = confusableSkeleton(raw);
+  if (!/^[\x00-\x7F]+$/.test(raw)) {
+    return { kind: "unicode", message: `package name '${raw}' contains non-ASCII or confusable Unicode characters` };
+  }
+  if (!/^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/.test(raw)) {
+    return { kind: "invalid", message: `package name '${raw}' is not a canonical npm registry name` };
+  }
+
+  const candidate = packageScope(skeleton);
+  for (const protectedName of protectedNames) {
+    const protectedPackage = packageScope(confusableSkeleton(protectedName));
+    if (skeleton === confusableSkeleton(protectedName)) continue;
+    if (Boolean(candidate.scope) !== Boolean(protectedPackage.scope)) continue;
+    const comparableCandidate = candidate.scope === protectedPackage.scope
+      ? candidate.leaf
+      : `${candidate.scope}/${candidate.leaf}`;
+    const comparableProtected = candidate.scope === protectedPackage.scope
+      ? protectedPackage.leaf
+      : `${protectedPackage.scope}/${protectedPackage.leaf}`;
+    if (Math.min(comparableCandidate.length, comparableProtected.length) < 4) continue;
+    if (Math.abs(comparableCandidate.length - comparableProtected.length) > 1) continue;
+    if (damerauLevenshtein(comparableCandidate, comparableProtected) === 1) {
+      return {
+        kind: "similar",
+        protectedName,
+        message: `package name '${raw}' is one edit or adjacent transposition from protected name '${protectedName}'`
+      };
+    }
+  }
+  return null;
+}
+
+export function hasTyposquatException(exceptions, packageName, version) {
+  return Array.isArray(exceptions) && exceptions.some((entry) =>
+    entry && entry.package === packageName && entry.version === version &&
+    isExactVersion(entry.version) && typeof entry.reason === "string" && entry.reason.trim().length > 0
+  );
+}
+
+function typosquatException(exceptions, packageName, version) {
+  return Array.isArray(exceptions) ? exceptions.find((entry) =>
+    entry && entry.package === packageName && entry.version === version &&
+    isExactVersion(entry.version) && typeof entry.reason === "string" && entry.reason.trim().length > 0
+  ) : undefined;
+}
+
+function collectDirectDependencies(manifest = {}) {
+  const collected = new Map();
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const [name, specifier] of Object.entries(manifest?.[field] || {})) {
+      collected.set(`${field}\0${name}`, { name, specifier: String(specifier), field });
+    }
+  }
+  return collected;
+}
+
+export function changedDirectDependencies(baseManifest = {}, headManifest = {}) {
+  const base = collectDirectDependencies(baseManifest);
+  const head = collectDirectDependencies(headManifest);
+  return [...head.values()].filter((entry) => {
+    const previous = base.get(`${entry.field}\0${entry.name}`);
+    return !previous || previous.specifier !== entry.specifier || previous.field !== entry.field;
+  });
+}
+
+export function parsePnpmLockImporters(text) {
+  const resolutions = new Map();
+  let importer = null;
+  let field = null;
+  let packageName = null;
+  let inImporters = false;
+
+  for (const line of String(text).split(/\r?\n/)) {
+    if (line === "importers:") {
+      inImporters = true;
+      continue;
+    }
+    if (!inImporters) continue;
+    if (/^\S/.test(line) && line.trim()) break;
+
+    const importerMatch = line.match(/^ {2}(\S.*):\s*$/);
+    if (importerMatch) {
+      importer = yamlScalar(importerMatch[1]);
+      field = null;
+      packageName = null;
+      continue;
+    }
+    const fieldMatch = line.match(/^ {4}(dependencies|devDependencies|optionalDependencies|peerDependencies):\s*$/);
+    if (fieldMatch) {
+      field = fieldMatch[1];
+      packageName = null;
+      continue;
+    }
+    const packageMatch = line.match(/^ {6}(\S.*):\s*$/);
+    if (packageMatch && importer && field) {
+      packageName = yamlScalar(packageMatch[1]);
+      continue;
+    }
+    const versionMatch = line.match(/^ {8}version:\s*(.+?)\s*$/);
+    if (versionMatch && importer && field && packageName) {
+      let version = yamlScalar(versionMatch[1]);
+      version = version.replace(/\(.+\)$/, "");
+      resolutions.set(`${importer}\0${field}\0${packageName}`, version);
+    }
+  }
+  return resolutions;
+}
+
+function importerForManifest(path) {
+  const directory = dirname(path).replaceAll("\\", "/");
+  return directory === "." ? "." : directory;
+}
+
+function resolveExactVersion(entry, manifestPath, lockResolutions) {
+  const locked = lockResolutions.get(`${importerForManifest(manifestPath)}\0${entry.field}\0${entry.name}`);
+  if (locked && isExactVersion(locked)) return locked.replace(/^v/, "");
+  if (isExactVersion(entry.specifier)) return entry.specifier.replace(/^v/, "");
+  return "";
+}
+
+function lockedResolution(entry, manifestPath, lockResolutions) {
+  return lockResolutions.get(`${importerForManifest(manifestPath)}\0${entry.field}\0${entry.name}`) || "";
+}
+
+export function validateLockfileRegistries(text) {
+  const errors = [];
+  const seen = new Set();
+  for (const match of String(text).matchAll(/https?:\/\/[^\s'"}\],)]+/gi)) {
+    const raw = match[0];
+    let allowed = false;
+    try {
+      const url = new URL(raw);
+      allowed = url.protocol === "https:" && url.hostname === "registry.npmjs.org" &&
+        !url.username && !url.password && (!url.port || url.port === "443");
+    } catch {
+      allowed = false;
+    }
+    if (!allowed && !seen.has(raw)) {
+      seen.add(raw);
+      errors.push("pnpm-lock.yaml contains a non-official package source");
+    }
+  }
+  const exotic = String(text).split(/\r?\n/).find((line) => {
+    if (/(?:^|[\s[{,])(?:git(?:\+[^:]+)?:|git@|ssh:|github:|gitlab:|bitbucket:|file:|link:|portal:|patch:|path:)/i.test(line)) {
+      return true;
+    }
+    const tarball = line.match(/tarball:\s*([^\s},]+)/i);
+    return tarball && !/^https:\/\/registry\.npmjs\.org\//i.test(tarball[1]);
+  });
+  if (exotic) errors.push("pnpm-lock.yaml contains a Git, local, patched, or archive package source");
+  return errors;
+}
+
+export function parseNpmrc(text) {
+  const registries = {
+    default: OFFICIAL_NPM_REGISTRY,
+    scopes: new Map(),
+    unsafeSettings: [],
+    unsafePolicySettings: []
+  };
+  for (const rawLine of String(text).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+    const key = line.split("=", 1)[0].trim().toLowerCase();
+    if (["proxy", "http-proxy", "https-proxy", "noproxy", "no-proxy", "pnpr-server"].includes(key)) {
+      registries.unsafeSettings.push(key);
+    }
+    const normalizedKey = key.replace(/[-_.\[\]]/g, "");
+    if ([
+      "dangerouslyallowallbuilds",
+      "allowbuilds",
+      "onlybuiltdependencies",
+      "onlybuiltdependenciesfile",
+      "ignoredbuiltdependencies",
+      "neverbuiltdependencies",
+      "strictdepbuilds",
+      "blockexoticsubdeps",
+      "minimumreleaseage",
+      "minimumreleaseageexclude",
+      "trustpolicy",
+      "trustpolicyexclude",
+      "trustpolicyignoreafter"
+    ].includes(normalizedKey)) {
+      registries.unsafePolicySettings.push(key);
+    }
+    const match = line.match(/^(@[^:]+:)?registry\s*=\s*(.+)$/i);
+    if (!match) continue;
+    const value = match[2].trim();
+    if (match[1]) registries.scopes.set(match[1].slice(0, -1), value);
+    else registries.default = value;
+  }
+  return registries;
+}
+
+function registryForPackage(name, npmrc) {
+  const scope = packageScope(name).scope;
+  return normalizeUrl((scope && npmrc.scopes.get(scope)) || npmrc.default || OFFICIAL_NPM_REGISTRY);
+}
+
+export function validateHashedRequirements(text, allowedIndexes = [OFFICIAL_PYTHON_INDEX]) {
+  const errors = [];
+  const logicalLines = [];
+  let current = "";
+  for (const rawLine of String(text).split(/\r?\n/)) {
+    const line = rawLine.replace(/\s+#.*$/, "").trim();
+    if (!line || line.startsWith("#")) continue;
+    current += `${current ? " " : ""}${line.replace(/\\\s*$/, "").trim()}`;
+    if (!/\\\s*$/.test(line)) {
+      logicalLines.push(current);
+      current = "";
+    }
+  }
+  if (current) logicalLines.push(current);
+  if (logicalLines.length === 0) errors.push("requirements lock is empty");
+
+  const normalizedIndexes = new Set(allowedIndexes.map((value) => normalizeUrl(value)));
+  for (const [indexNumber, line] of logicalLines.entries()) {
+    const entryLabel = `requirements entry ${indexNumber + 1}`;
+    const index = line.match(/^--(?:extra-)?index-url\s+(.+)$/);
+    if (index) {
+      if (!normalizedIndexes.has(normalizeUrl(index[1]))) errors.push(`${entryLabel} declares an unknown Python index`);
+      continue;
+    }
+    if (line.startsWith("--")) {
+      errors.push(`${entryLabel} uses an unsupported requirements option`);
+      continue;
+    }
+    if (/(?:git\+|https?:\/\/|file:|\.\.\/|\.\/)/i.test(line)) {
+      errors.push(`${entryLabel} uses a forbidden non-registry Python dependency`);
+      continue;
+    }
+    const exactPin = line.match(/^[A-Za-z0-9_.-]+(?:\[[^\]]+\])?==([^\s;]+)(?:\s|$)/);
+    if (!exactPin || exactPin[1].includes("*") || exactPin[1].includes(",")) {
+      errors.push(`${entryLabel} must use an exact == pin`);
+    }
+    if (!/--hash=sha256:[a-fA-F0-9]{64}(?:\s|$)/.test(line)) {
+      errors.push(`${entryLabel} is missing a sha256 hash`);
+    }
+  }
+  return errors;
+}
+
+function git(root, args, { allowFailure = false } = {}) {
+  try {
+    return execFileSync("git", args, { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (error) {
+    if (allowFailure) return null;
+    throw error;
+  }
+}
+
+function jsonAtRef(root, ref, path) {
+  const content = git(root, ["show", `${ref}:${path}`], { allowFailure: true });
+  if (content === null) return {};
+  return JSON.parse(content);
+}
+
+function manifestPathsAtRef(root, ref) {
+  const output = git(root, ["ls-tree", "-r", "--name-only", ref]);
+  return output.split(/\r?\n/).filter((path) => basename(path) === "package.json");
+}
+
+function textAtRef(root, ref, path) {
+  return git(root, ["show", `${ref}:${path}`], { allowFailure: true });
+}
+
+function runFrozenLockCheck(root, runCommand = execFileSync) {
+  if (!existsSync(join(root, "pnpm-lock.yaml"))) {
+    return ["pnpm-lock.yaml is required; dependency installation was not verified"];
+  }
+  try {
+    runCommand("pnpm", [
+      "install",
+      "--lockfile-only",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--ignore-pnpmfile"
+    ], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    return [];
+  } catch (error) {
+    return ["pnpm lockfile is missing or stale; frozen verification failed"];
+  }
+}
+
+function uvIndexErrors(root, allowedIndexes) {
+  const errors = [];
+  const normalized = new Set(allowedIndexes.map((value) => normalizeUrl(value)));
+  const uvLock = readFileSync(join(root, "uv.lock"), "utf8");
+  for (const match of uvLock.matchAll(/registry\s*=\s*["']([^"']+)["']/g)) {
+    if (!normalized.has(normalizeUrl(match[1]))) errors.push("unknown Python index in uv.lock");
+  }
+  for (const match of uvLock.matchAll(/^\s*source\s*=\s*\{([^}]*)\}\s*$/gm)) {
+    const source = match[1].trim();
+    if (/^registry\s*=/.test(source)) continue;
+    if (/^(?:editable|virtual)\s*=\s*["']\.["']$/.test(source)) continue;
+    errors.push("uv.lock contains a forbidden Git, URL, or local dependency source");
+  }
+
+  const pyproject = readFileSync(join(root, "pyproject.toml"), "utf8");
+  let inUvIndex = false;
+  let inUvSources = false;
+  for (const line of pyproject.split(/\r?\n/)) {
+    if (/^\s*\[\[tool\.uv\.index\]\]\s*$/.test(line)) {
+      inUvIndex = true;
+      inUvSources = false;
+      continue;
+    }
+    if (/^\s*\[tool\.uv\.sources\]\s*$/.test(line)) {
+      inUvSources = true;
+      inUvIndex = false;
+      continue;
+    }
+    if (/^\s*\[/.test(line)) {
+      inUvIndex = false;
+      inUvSources = false;
+    }
+    if (/@\s*(?:git\+|https?:\/\/|file:|\.{0,2}\/)/i.test(line)) {
+      errors.push("pyproject.toml contains a forbidden direct Git, URL, or local dependency");
+    }
+    if (inUvSources && /\b(?:git|url|path|workspace)\s*=/.test(line)) {
+      errors.push("pyproject.toml contains a forbidden tool.uv.sources dependency");
+    }
+    if (!inUvIndex) continue;
+    const match = line.match(/^\s*url\s*=\s*["']([^"']+)["']/);
+    if (match && !normalized.has(normalizeUrl(match[1]))) errors.push("unknown Python index in pyproject.toml");
+  }
+  return errors;
+}
+
+function pythonPolicyEnabled(config) {
+  return PYTHON_PROFILES.has(config.profile) || config.dependencyPolicy?.python?.enabled === true;
+}
+
+export function validatePythonContract(root, config, runCommand = execFileSync) {
+  const pythonPolicy = config.dependencyPolicy?.python || {};
+  const enabled = pythonPolicyEnabled(config);
+  if (!enabled) return [];
+
+  const errors = [];
+  const allowedIndexes = [OFFICIAL_PYTHON_INDEX];
+  if (existsSync(join(root, "uv.lock"))) {
+    if (!repositoryRegularFile(root, "uv.lock") || !repositoryRegularFile(root, "pyproject.toml")) {
+      return ["uv.lock and pyproject.toml must be regular, non-symlink repository files"];
+    }
+    errors.push(...uvIndexErrors(root, allowedIndexes));
+    if (errors.length > 0) return errors;
+    try {
+      runCommand("uv", ["lock", "--check"], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+    } catch (error) {
+      const detail = String(error?.stderr || error?.stdout || error?.message || "").trim();
+      errors.push(`uv lock was not verified as current${detail ? `: ${detail}` : ""}`);
+    }
+    return errors;
+  }
+
+  const lockFile = String(pythonPolicy.requirementsLockFile || "requirements.lock");
+  const pathCandidate = repositoryPath(root, lockFile);
+  if (!pathCandidate) return ["requirementsLockFile must be a repository-relative file path"];
+  if (!existsSync(pathCandidate)) {
+    return [`Python dependency policy requires uv.lock or hashed ${lockFile}`];
+  }
+  const lockPath = repositoryRegularFile(root, lockFile);
+  if (!lockPath) return ["requirementsLockFile must be a regular, non-symlink repository file outside trusted control paths"];
+  errors.push(...validateHashedRequirements(readFileSync(lockPath, "utf8"), allowedIndexes));
+  const installCommand = String(config.commands?.install || "");
+  if (!installCommand.includes("--isolated") ||
+      !installCommand.includes(`--index-url ${OFFICIAL_PYTHON_INDEX}`) ||
+      !installCommand.includes("--require-hashes") ||
+      !installCommand.includes("--only-binary :all:")) {
+    errors.push("hashed Python installs must use isolated pip, the official index, --require-hashes, and --only-binary :all:");
+  }
+  return errors;
+}
+
+export function syncPythonContract(root, config, runCommand = execFileSync) {
+  const pythonPolicy = config.dependencyPolicy?.python || {};
+  const enabled = pythonPolicyEnabled(config);
+  if (!enabled) return [];
+  try {
+    if (existsSync(join(root, "uv.lock"))) {
+      if (!repositoryRegularFile(root, "uv.lock") || !repositoryRegularFile(root, "pyproject.toml")) {
+        return ["uv.lock and pyproject.toml must be regular, non-symlink repository files"];
+      }
+      runCommand("uv", ["sync", "--locked"], { cwd: root, stdio: "inherit" });
+    } else {
+      const lockFile = String(pythonPolicy.requirementsLockFile || "requirements.lock");
+      if (!repositoryRegularFile(root, lockFile)) {
+        return ["requirementsLockFile must be a regular, non-symlink repository file outside trusted control paths"];
+      }
+      runCommand(
+        "python",
+        [
+          "-m",
+          "pip",
+          "--isolated",
+          "install",
+          "--index-url",
+          OFFICIAL_PYTHON_INDEX,
+          "--require-hashes",
+          "--only-binary",
+          ":all:",
+          "-r",
+          lockFile
+        ],
+        { cwd: root, stdio: "inherit" }
+      );
+    }
+    return [];
+  } catch (error) {
+    return [`locked Python dependency sync failed: ${error.message}`];
+  }
+}
+
+async function registryMetadata(name, registry, fetchImpl, timeoutMilliseconds) {
+  const encodedName = name.startsWith("@") ? name.replace("/", "%2F") : encodeURIComponent(name);
+  let response;
+  try {
+    response = await fetchImpl(new URL(encodedName, registry), {
+      // Full packument metadata is required for per-version publication times
+      // and lifecycle scripts; abbreviated install metadata does not guarantee them.
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(timeoutMilliseconds)
+    });
+  } catch (error) {
+    return { error: `registry metadata for '${name}' was not verified: ${error.message}` };
+  }
+  if (response.status === 404) return { error: `registry package '${name}' does not exist` };
+  if (!response.ok) return { error: `registry metadata for '${name}' was not verified: HTTP ${response.status}` };
+  try {
+    return { metadata: await response.json() };
+  } catch (error) {
+    return { error: `registry metadata for '${name}' was not verified: invalid JSON (${error.message})` };
+  }
+}
+
+export async function verifyChangedDependency({
+  entry,
+  version,
+  registry,
+  workspacePolicy,
+  nodePolicy = {},
+  baseTyposquatExceptions = [],
+  protectedNames = DEFAULT_PROTECTED_PACKAGE_NAMES,
+  fetchImpl = fetch,
+  now = Date.now(),
+  requireInstallScript = false
+}) {
+  const errors = [];
+  const specifier = classifyDependencySpecifier(entry.specifier);
+  if (!specifier.allowed) return [`${entry.name}@${entry.specifier}: ${specifier.reason}`];
+  if (!version) return [`${entry.name}@${entry.specifier}: exact locked version was not verified`];
+
+  const suspicious = findSuspiciousName(entry.name, protectedNames);
+  if (suspicious) {
+    const exception = typosquatException(nodePolicy.typosquatExceptions, entry.name, version);
+    const baseException = typosquatException(baseTyposquatExceptions, entry.name, version);
+    if (!exception) {
+      errors.push(`${suspicious.message}; add a version-scoped dependencyPolicy.node.typosquatExceptions entry with a reason to review it explicitly`);
+    } else if (baseException && baseException.reason === exception.reason) {
+      errors.push(`${suspicious.message}; its version-scoped exception must be added or materially changed in this diff`);
+    }
+  }
+
+  const result = await registryMetadata(entry.name, registry, fetchImpl, configuredRegistryTimeout(nodePolicy));
+  if (result.error) return [...errors, result.error];
+  const metadata = result.metadata;
+  const versionMetadata = metadata?.versions?.[version];
+  if (!versionMetadata) {
+    errors.push(`registry version '${entry.name}@${version}' does not exist`);
+    return errors;
+  }
+  const publishedAt = metadata?.time?.[version];
+  const publishedTime = Date.parse(publishedAt || "");
+  if (!Number.isFinite(publishedTime)) {
+    errors.push(`publication date for '${entry.name}@${version}' was not verified`);
+  } else {
+    const minimumAge = configuredMinimumReleaseAge(nodePolicy);
+    if (now - publishedTime < minimumAge * 60_000) {
+      errors.push(`'${entry.name}@${version}' is younger than the ${minimumAge}-minute minimum release age`);
+    }
+  }
+
+  const scripts = versionMetadata.scripts || {};
+  const installScripts = INSTALL_SCRIPT_NAMES.filter((name) => typeof scripts[name] === "string" && scripts[name].trim());
+  if (requireInstallScript && installScripts.length === 0) {
+    errors.push(`'${entry.name}@${version}' has no install lifecycle script to justify allowBuilds`);
+  }
+  if (installScripts.length > 0 && workspacePolicy.allowBuilds.get(`${entry.name}@${version}`) !== true) {
+    errors.push(`'${entry.name}@${version}' declares ${installScripts.join(", ")} and is not allowed by exact-version allowBuilds`);
+  }
+  return errors;
+}
+
+export async function runDependencyPolicy({
+  root,
+  baseRef,
+  headRef,
+  fetchImpl = fetch,
+  runCommand = execFileSync,
+  now = Date.now()
+}) {
+  const errors = [];
+  if (!repositoryRegularFile(root, ".unicorn-hub/config.json")) {
+    return [".unicorn-hub/config.json must be a regular, non-symlink repository file"];
+  }
+  const config = readConfig(root);
+  const nodePolicy = config.dependencyPolicy?.node || {};
+  const configuredAge = Number(nodePolicy.minimumReleaseAgeMinutes ?? 10080);
+  if (!Number.isSafeInteger(configuredAge) || configuredAge < 10080) {
+    errors.push("dependencyPolicy.node.minimumReleaseAgeMinutes must be an integer of at least 10080");
+  }
+  const configuredTimeout = Number(nodePolicy.registryTimeoutMilliseconds ?? 10000);
+  if (!Number.isSafeInteger(configuredTimeout) || configuredTimeout < 1000 || configuredTimeout > 30000) {
+    errors.push("dependencyPolicy.node.registryTimeoutMilliseconds must be an integer from 1000 through 30000");
+  }
+  const minimumAge = configuredMinimumReleaseAge(nodePolicy);
+  const workspacePath = repositoryRegularFile(root, "pnpm-workspace.yaml");
+  if (!workspacePath) {
+    errors.push("pnpm-workspace.yaml must be a regular, non-symlink repository file");
+    return errors;
+  }
+  const workspaceValidation = validateWorkspacePolicy(readFileSync(workspacePath, "utf8"), minimumAge);
+  errors.push(...workspaceValidation.errors.map((error) => `pnpm workspace policy: ${error}`));
+  const localLockCandidate = repositoryPath(root, "pnpm-lock.yaml");
+  const localLockPath = repositoryRegularFile(root, "pnpm-lock.yaml");
+  if (!localLockCandidate || !existsSync(localLockCandidate)) {
+    errors.push("pnpm-lock.yaml is required; dependency installation was not verified");
+  } else if (!localLockPath) {
+    errors.push("pnpm-lock.yaml must be a regular, non-symlink repository file");
+  } else {
+    errors.push(...validateLockfileRegistries(readFileSync(localLockPath, "utf8")));
+  }
+  const npmrcCandidate = repositoryPath(root, ".npmrc");
+  if (npmrcCandidate && existsSync(npmrcCandidate) && !repositoryRegularFile(root, ".npmrc")) {
+    errors.push(".npmrc must be a regular, non-symlink repository file");
+  }
+  const npmrcPath = repositoryRegularFile(root, ".npmrc");
+  const npmrc = parseNpmrc(npmrcPath ? readFileSync(npmrcPath, "utf8") : "");
+  const allowedRegistry = normalizeUrl(OFFICIAL_NPM_REGISTRY);
+  for (const [label, registry] of [["default", npmrc.default], ...npmrc.scopes.entries()]) {
+    if (normalizeUrl(registry) !== allowedRegistry) {
+      errors.push(`unknown ${label === "default" ? "default" : `${label} scoped`} npm registry`);
+    }
+  }
+  for (const setting of npmrc.unsafeSettings) {
+    errors.push(`project .npmrc request-routing setting '${setting}' is not supported`);
+  }
+  for (const setting of npmrc.unsafePolicySettings) {
+    errors.push(`project .npmrc dependency-policy override '${setting}' is not supported`);
+  }
+  let baseManifestPaths = [];
+  let headManifestPaths = [];
+  if (!baseRef || !headRef) {
+    errors.push("base and head git refs are required to verify changed direct dependencies");
+  } else {
+    try {
+      baseManifestPaths = manifestPathsAtRef(root, baseRef);
+      headManifestPaths = manifestPathsAtRef(root, headRef);
+      for (const manifestPath of headManifestPaths) {
+        if (!repositoryRegularFile(root, manifestPath)) {
+          errors.push(`package manifest '${manifestPath}' must be a regular, non-symlink repository file`);
+        }
+      }
+    } catch {
+      errors.push("base and head git refs were not resolved for dependency verification");
+    }
+  }
+  if (errors.length > 0) return errors;
+
+  errors.push(...runFrozenLockCheck(root, runCommand));
+  if (errors.length > 0) return errors;
+  errors.push(...validatePythonContract(root, config, runCommand));
+  if (errors.length > 0) return errors;
+
+  const baseConfig = jsonAtRef(root, baseRef, ".unicorn-hub/config.json");
+  if (pythonPolicyEnabled(baseConfig) && !pythonPolicyEnabled(config)) {
+    errors.push("Python dependency policy cannot be disabled for a repository that already requires it");
+  }
+  const headLockText = textAtRef(root, headRef, "pnpm-lock.yaml") ?? readFileSync(join(root, "pnpm-lock.yaml"), "utf8");
+  const baseLockText = textAtRef(root, baseRef, "pnpm-lock.yaml") || "";
+  errors.push(...validateLockfileRegistries(headLockText));
+  const lockResolutions = parsePnpmLockImporters(headLockText);
+  const baseLockResolutions = parsePnpmLockImporters(baseLockText);
+  const baseWorkspaceText = textAtRef(root, baseRef, "pnpm-workspace.yaml") || "";
+  const baseWorkspacePolicy = parseWorkspacePolicy(baseWorkspaceText);
+  const manifests = [...new Set([
+    ...baseManifestPaths,
+    ...headManifestPaths
+  ])].sort();
+  const manifestPairs = manifests.map((manifestPath) => ({
+    manifestPath,
+    baseManifest: jsonAtRef(root, baseRef, manifestPath),
+    headManifest: jsonAtRef(root, headRef, manifestPath)
+  }));
+  const protectedNames = new Set([
+    ...DEFAULT_PROTECTED_PACKAGE_NAMES,
+    ...(Array.isArray(baseConfig.dependencyPolicy?.node?.protectedPackageNames)
+      ? baseConfig.dependencyPolicy.node.protectedPackageNames
+      : []),
+    ...(Array.isArray(nodePolicy.protectedPackageNames) ? nodePolicy.protectedPackageNames : [])
+  ]);
+  for (const { baseManifest } of manifestPairs) {
+    for (const dependency of collectDirectDependencies(baseManifest).values()) protectedNames.add(dependency.name);
+  }
+
+  for (const { manifestPath, baseManifest, headManifest } of manifestPairs) {
+    const manifestChanges = new Set(changedDirectDependencies(baseManifest, headManifest)
+      .map((entry) => `${entry.field}\0${entry.name}`));
+    const baseDependencies = collectDirectDependencies(baseManifest);
+    const dependencyChanges = [...collectDirectDependencies(headManifest).values()].filter((entry) => {
+      const key = `${entry.field}\0${entry.name}`;
+      if (manifestChanges.has(key)) return true;
+      const previous = baseDependencies.get(key);
+      if (!previous) return true;
+      return lockedResolution(previous, manifestPath, baseLockResolutions) !==
+        lockedResolution(entry, manifestPath, lockResolutions);
+    });
+    for (const entry of dependencyChanges) {
+      const selectedRegistry = registryForPackage(entry.name, npmrc);
+      if (selectedRegistry !== allowedRegistry) {
+        errors.push(`${manifestPath}: unknown registry for '${entry.name}'`);
+        continue;
+      }
+      const version = resolveExactVersion(entry, manifestPath, lockResolutions);
+      const dependencyErrors = await verifyChangedDependency({
+        entry,
+        version,
+        registry: selectedRegistry,
+        workspacePolicy: workspaceValidation.policy,
+        nodePolicy,
+        baseTyposquatExceptions: baseConfig.dependencyPolicy?.node?.typosquatExceptions || [],
+        protectedNames,
+        fetchImpl,
+        now
+      });
+      errors.push(...dependencyErrors.map((error) => `${manifestPath}: ${error}`));
+    }
+  }
+
+  for (const [matcher, allowed] of workspaceValidation.policy.allowBuilds) {
+    if (!allowed || baseWorkspacePolicy.allowBuilds.get(matcher) === true) continue;
+    const parsed = splitVersionScopedMatcher(matcher);
+    if (!parsed) continue;
+    const selectedRegistry = registryForPackage(parsed.name, npmrc);
+    if (selectedRegistry !== allowedRegistry) continue;
+    const buildErrors = await verifyChangedDependency({
+      entry: { name: parsed.name, specifier: parsed.version, field: "dependencies" },
+      version: parsed.version,
+      registry: selectedRegistry,
+      workspacePolicy: workspaceValidation.policy,
+      nodePolicy,
+      baseTyposquatExceptions: baseConfig.dependencyPolicy?.node?.typosquatExceptions || [],
+      protectedNames,
+      fetchImpl,
+      now,
+      requireInstallScript: true
+    });
+    errors.push(...buildErrors.map((error) => `pnpm-workspace.yaml: ${error}`));
+  }
+  return errors;
+}
+
+async function main() {
+  const args = parseArgs();
+  const root = resolve(args.target || findRepoRoot());
+  const [positionalBase, positionalHead] = args._ || [];
+  const baseRef = String(args.base || positionalBase || "");
+  const headRef = String(args.head || positionalHead || "");
+  const errors = await runDependencyPolicy({ root, baseRef, headRef });
+  if (errors.length === 0 && args["sync-python"]) {
+    errors.push(...syncPythonContract(root, readConfig(root)));
+  }
+  if (errors.length > 0) {
+    console.error("Dependency policy check failed:");
+    for (const error of errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log("Dependency policy check passed.");
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) await main();

--- a/scripts/check-dependency-policy.mjs
+++ b/scripts/check-dependency-policy.mjs
@@ -7,6 +7,7 @@ import { findRepoRoot, parseArgs, readConfig } from "./shared.mjs";
 
 const OFFICIAL_NPM_REGISTRY = "https://registry.npmjs.org/";
 const OFFICIAL_PYTHON_INDEX = "https://pypi.org/simple";
+const OFFICIAL_PYTHON_ARTIFACT_ORIGIN = "https://files.pythonhosted.org";
 const PYTHON_PROFILES = new Set(["python-service", "telegram-bot"]);
 const DEPENDENCY_FIELDS = [
   "dependencies",
@@ -614,6 +615,17 @@ function uvIndexErrors(root, allowedIndexes) {
   const uvLock = readFileSync(join(root, "uv.lock"), "utf8");
   for (const match of uvLock.matchAll(/registry\s*=\s*["']([^"']+)["']/g)) {
     if (!normalized.has(normalizeUrl(match[1]))) errors.push("unknown Python index in uv.lock");
+  }
+  for (const match of uvLock.matchAll(/\burl\s*=\s*["']([^"']+)["']/g)) {
+    try {
+      const url = new URL(match[1]);
+      if (url.origin !== OFFICIAL_PYTHON_ARTIFACT_ORIGIN ||
+          url.username || url.password || !url.pathname.startsWith("/packages/")) {
+        errors.push("uv.lock contains a non-official Python artifact URL");
+      }
+    } catch {
+      errors.push("uv.lock contains an invalid Python artifact URL");
+    }
   }
   for (const match of uvLock.matchAll(/^\s*source\s*=\s*\{([^}]*)\}\s*$/gm)) {
     const source = match[1].trim();

--- a/scripts/check-repo-baseline.mjs
+++ b/scripts/check-repo-baseline.mjs
@@ -14,6 +14,8 @@ function requirePath(path) {
 
 requirePath("README.md");
 requirePath("package.json");
+requirePath("pnpm-lock.yaml");
+requirePath("pnpm-workspace.yaml");
 requirePath(".unicorn-hub/config.json");
 requirePath(config.docsDir || "docs_project");
 
@@ -29,6 +31,7 @@ if (config.blueprint) {
     "templates/.github/workflows/osv-scan.yml",
     "scripts/bootstrap-repo.mjs",
     "scripts/check-context-budget.mjs",
+    "scripts/check-dependency-policy.mjs",
     "scripts/check-feature-memory.mjs",
     "scripts/ai-command-policy.mjs",
     "scripts/ai-review-gate.mjs",
@@ -51,6 +54,7 @@ if (config.blueprint) {
     ".specify/memory/constitution.md",
     config.specsDir || "specs",
     "scripts/check-context-budget.mjs",
+    "scripts/check-dependency-policy.mjs",
     "scripts/check-feature-memory.mjs",
     "scripts/check-repo-baseline.mjs",
     "scripts/ai-command-policy.mjs",
@@ -75,8 +79,15 @@ if (missing.length) {
 }
 
 const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
-if (!packageJson.packageManager?.startsWith("pnpm@")) {
-  console.error("package.json must pin packageManager to pnpm@<version>.");
+const pnpmVersion = String(packageJson.packageManager || "").match(/^pnpm@(\d+)\.(\d+)\.(\d+)(?:\+.*)?$/);
+if (!pnpmVersion) {
+  console.error("package.json must pin packageManager to an exact pnpm@<version>.");
+  process.exit(1);
+}
+const [, pnpmMajor, pnpmMinor, pnpmPatch] = pnpmVersion.map(Number);
+if (pnpmMajor < 10 ||
+    (pnpmMajor === 10 && (pnpmMinor < 34 || (pnpmMinor === 34 && pnpmPatch < 5)))) {
+  console.error("packageManager must be pnpm@10.34.5 or newer for dependency-policy security fixes.");
   process.exit(1);
 }
 

--- a/specs/013-dependency-install-guard/plan.md
+++ b/specs/013-dependency-install-guard/plan.md
@@ -38,7 +38,7 @@ The checker centralizes related dependency policy because source validation, loc
 | AC-004 | Mock-registry tests for valid, missing, young, and unavailable metadata. |
 | AC-005 | Synthetic typo, transposition, Unicode, and exception tests. |
 | AC-006 | Exact-version allowBuilds assertions, unknown/allowed install-script tests, and fail-closed pnpmfile hook tests. |
-| AC-007 | Python profile/config assertions and hashed-lock/uv contract tests. |
+| AC-007 | Python profile/config assertions plus hashed-lock/uv tests proving the guard does not build or install PR project sources. |
 | AC-008 | Bootstrap tests for installed files, settings, config, collision preservation, and forced refresh. |
 | AC-009 | Root/template PR Guard parity test showing the checker runs inside `guard`. |
 
@@ -59,3 +59,5 @@ Negative scenario evidence:
   Mitigation: support the preferred uv contract plus one hashed pip lock contract only for Python-enabled profiles.
 - Risk: pnpmfile hooks can rewrite dependency manifests during a frozen install.
   Mitigation: reject default hook files and local/global pnpmfile settings before invoking pnpm.
+- Risk: syncing a PR-controlled Python project can execute its local PEP 517 backend.
+  Mitigation: validate and sync uv locks with source builds disabled, and omit the current project from the guard environment.

--- a/specs/013-dependency-install-guard/plan.md
+++ b/specs/013-dependency-install-guard/plan.md
@@ -33,7 +33,7 @@ The checker centralizes related dependency policy because source validation, loc
 | Acceptance criterion | Evidence |
 | --- | --- |
 | AC-001 | Workspace parity assertions and pnpm configuration tests. |
-| AC-002 | Workflow assertions plus synthetic missing/stale lockfile CLI tests. |
+| AC-002 | Workflow assertions for frozen, script-free PR installation plus synthetic missing/stale lockfile CLI tests. |
 | AC-003 | Dependency-policy tests for direct diff scope and forbidden source forms. |
 | AC-004 | Mock-registry tests for valid, missing, young, and unavailable metadata. |
 | AC-005 | Synthetic typo, transposition, Unicode, and exception tests. |
@@ -65,3 +65,5 @@ Negative scenario evidence:
   Mitigation: validate every uv artifact URL against the exact official PyPI distribution origin and path before invoking uv.
 - Risk: pnpm graph-rewrite settings can inject transitive dependencies without changing a direct declaration.
   Mitigation: reject overrides, package extensions, and patched dependencies in workspace and manifest policy before invoking pnpm.
+- Risk: independent CI can execute an allowed dependency lifecycle script before the trusted PR Guard finishes.
+  Mitigation: keep pull-request CI installation script- and pnpmfile-free; retain exact allowBuilds entries as reviewed evidence for trusted later installs.

--- a/specs/013-dependency-install-guard/plan.md
+++ b/specs/013-dependency-install-guard/plan.md
@@ -1,0 +1,59 @@
+# Plan: Portable Dependency Install Guard
+
+## Summary
+
+Implement one dependency-free Node checker with explicit base/head inputs, deterministic policy helpers, official-registry verification, pnpm lock/install-script enforcement, and profile-scoped Python lock validation. Install it through bootstrap, invoke it inside the existing PR Guard, and document the strict contracts.
+
+## Technical Context
+
+- runtime: Node.js 20+ ESM; pnpm 10.34.5; Python policy invokes `uv` or pip only through documented CI/profile commands
+- dependencies: no new runtime libraries; Node built-ins and package-manager CLIs only
+- product paths: workspace settings, package/config templates, workflows, scripts, profiles, tests, docs, feature memory
+- data changes: configuration schema gains dependency-policy fields and version-scoped exception records
+
+## Scope Boundaries
+
+- in scope: direct-dependency diff validation, registry metadata checks, name heuristics, exact-version install-script policy, Node/Python lock contracts, bootstrap propagation
+- out of scope: transitive-package reputation scoring, branch protection, GitHub Advanced Security configuration, new required checks
+
+## Constitution Check
+
+- Spec-first: this feature memory is created before implementation changes.
+- Testable boundaries: registry access is injectable for deterministic unit tests; CLI behavior is covered with synthetic repositories.
+- PR-only: implementation remains on `codex/dependency-install-guard` and will be published as a ready PR.
+- Simplicity: one small checker and configuration object; no database or service.
+- Deployability: the existing `guard` context and bootstrap managed-file rules remain intact.
+
+## Complexity Tracking
+
+The checker centralizes related dependency policy because source validation, lock resolution, name analysis, registry metadata, and Python lock contracts must produce one fail-closed result. Its pure helpers and injectable fetch boundary keep the logic testable without introducing external packages or a service.
+
+## Verification
+
+| Acceptance criterion | Evidence |
+| --- | --- |
+| AC-001 | Workspace parity assertions and pnpm configuration tests. |
+| AC-002 | Workflow assertions plus synthetic missing/stale lockfile CLI tests. |
+| AC-003 | Dependency-policy tests for direct diff scope and forbidden source forms. |
+| AC-004 | Mock-registry tests for valid, missing, young, and unavailable metadata. |
+| AC-005 | Synthetic typo, transposition, Unicode, and exception tests. |
+| AC-006 | Exact-version allowBuilds assertions and unknown/allowed install-script tests. |
+| AC-007 | Python profile/config assertions and hashed-lock/uv contract tests. |
+| AC-008 | Bootstrap tests for installed files, settings, config, collision preservation, and forced refresh. |
+| AC-009 | Root/template PR Guard parity test showing the checker runs inside `guard`. |
+
+Negative scenario evidence:
+
+- Run the focused dependency-policy test suite covering NS-001 through NS-008.
+- Run `pnpm run preflight` for sanitizer, baseline, workflow sync, syntax, and full tests.
+
+## Risks
+
+- Risk: range declarations cannot be verified as exact versions from registry metadata alone.
+  Mitigation: resolve the direct package/version from the committed pnpm lockfile and require a single exact version.
+- Risk: simple name similarity can produce false positives.
+  Mitigation: compare against a small configurable protected-name set and require narrow exact-version exceptions with reasons.
+- Risk: first-install PR Guard cannot use a checker absent from the default branch.
+  Mitigation: mirror the existing trusted-script fallback used by other guard scripts and fail clearly if neither copy exists.
+- Risk: Python projects vary in tooling.
+  Mitigation: support the preferred uv contract plus one hashed pip lock contract only for Python-enabled profiles.

--- a/specs/013-dependency-install-guard/plan.md
+++ b/specs/013-dependency-install-guard/plan.md
@@ -38,7 +38,7 @@ The checker centralizes related dependency policy because source validation, loc
 | AC-004 | Mock-registry tests for valid, missing, young, and unavailable metadata. |
 | AC-005 | Synthetic typo, transposition, Unicode, and exception tests. |
 | AC-006 | Exact-version allowBuilds assertions, unknown/allowed install-script tests, and fail-closed pnpmfile hook tests. |
-| AC-007 | Python profile/config assertions plus hashed-lock/uv tests proving the guard does not build or install PR project sources. |
+| AC-007 | Python profile/config assertions plus hashed-lock/uv tests proving the guard does not build or install PR project sources and rejects non-official artifact URLs. |
 | AC-008 | Bootstrap tests for installed files, settings, config, collision preservation, and forced refresh. |
 | AC-009 | Root/template PR Guard parity test showing the checker runs inside `guard`. |
 
@@ -61,3 +61,5 @@ Negative scenario evidence:
   Mitigation: reject default hook files and local/global pnpmfile settings before invoking pnpm.
 - Risk: syncing a PR-controlled Python project can execute its local PEP 517 backend.
   Mitigation: validate and sync uv locks with source builds disabled, and omit the current project from the guard environment.
+- Risk: a lockfile can retain an official registry while pointing an artifact URL at another host.
+  Mitigation: validate every uv artifact URL against the exact official PyPI distribution origin and path before invoking uv.

--- a/specs/013-dependency-install-guard/plan.md
+++ b/specs/013-dependency-install-guard/plan.md
@@ -44,7 +44,7 @@ The checker centralizes related dependency policy because source validation, loc
 
 Negative scenario evidence:
 
-- Run the focused dependency-policy test suite covering NS-001 through NS-008.
+- Run the focused dependency-policy test suite covering NS-001 through NS-010.
 - Run `pnpm run preflight` for sanitizer, baseline, workflow sync, syntax, and full tests.
 
 ## Risks
@@ -63,3 +63,5 @@ Negative scenario evidence:
   Mitigation: validate and sync uv locks with source builds disabled, and omit the current project from the guard environment.
 - Risk: a lockfile can retain an official registry while pointing an artifact URL at another host.
   Mitigation: validate every uv artifact URL against the exact official PyPI distribution origin and path before invoking uv.
+- Risk: pnpm graph-rewrite settings can inject transitive dependencies without changing a direct declaration.
+  Mitigation: reject overrides, package extensions, and patched dependencies in workspace and manifest policy before invoking pnpm.

--- a/specs/013-dependency-install-guard/plan.md
+++ b/specs/013-dependency-install-guard/plan.md
@@ -37,7 +37,7 @@ The checker centralizes related dependency policy because source validation, loc
 | AC-003 | Dependency-policy tests for direct diff scope and forbidden source forms. |
 | AC-004 | Mock-registry tests for valid, missing, young, and unavailable metadata. |
 | AC-005 | Synthetic typo, transposition, Unicode, and exception tests. |
-| AC-006 | Exact-version allowBuilds assertions and unknown/allowed install-script tests. |
+| AC-006 | Exact-version allowBuilds assertions, unknown/allowed install-script tests, and fail-closed pnpmfile hook tests. |
 | AC-007 | Python profile/config assertions and hashed-lock/uv contract tests. |
 | AC-008 | Bootstrap tests for installed files, settings, config, collision preservation, and forced refresh. |
 | AC-009 | Root/template PR Guard parity test showing the checker runs inside `guard`. |
@@ -57,3 +57,5 @@ Negative scenario evidence:
   Mitigation: mirror the existing trusted-script fallback used by other guard scripts and fail clearly if neither copy exists.
 - Risk: Python projects vary in tooling.
   Mitigation: support the preferred uv contract plus one hashed pip lock contract only for Python-enabled profiles.
+- Risk: pnpmfile hooks can rewrite dependency manifests during a frozen install.
+  Mitigation: reject default hook files and local/global pnpmfile settings before invoking pnpm.

--- a/specs/013-dependency-install-guard/spec.md
+++ b/specs/013-dependency-install-guard/spec.md
@@ -40,7 +40,7 @@ As a Python profile maintainer, I want either a locked `uv` workflow or a fully 
 ## Acceptance Criteria
 
 - AC-001: Root and template pnpm settings retain `minimumReleaseAge: 10080` and enable `blockExoticSubdeps`, `trustPolicy: no-downgrade`, `strictDepBuilds`, and an explicit `allowBuilds` map without globally allowing lifecycle scripts.
-- AC-002: Node CI and repository validation fail when `pnpm-lock.yaml` is missing or stale and install only with `pnpm install --frozen-lockfile`.
+- AC-002: Node CI and repository validation fail when `pnpm-lock.yaml` is missing or stale; PR CI uses a frozen install with lifecycle scripts and pnpmfile hooks disabled until trusted dependency policy has passed.
 - AC-003: The existing `guard` job checks only new or changed direct dependency declarations and rejects Git, URL, tarball/archive, local, unknown-registry, and pnpm dependency-graph rewrite sources.
 - AC-004: Registry dependencies pass only when the exact package name and resolved exact version exist in the configured official registry and the publication timestamp satisfies the configured minimum age; registry unavailability is reported as not verified and fails the check.
 - AC-005: Obvious misspellings, adjacent transpositions, and Unicode substitutions are blocked until a version-scoped exception with a non-empty reason is present in `.unicorn-hub/config.json`.

--- a/specs/013-dependency-install-guard/spec.md
+++ b/specs/013-dependency-install-guard/spec.md
@@ -44,7 +44,7 @@ As a Python profile maintainer, I want either a locked `uv` workflow or a fully 
 - AC-003: The existing `guard` job checks only new or changed direct dependency declarations and rejects Git, URL, tarball/archive, local, and unknown-registry sources.
 - AC-004: Registry dependencies pass only when the exact package name and resolved exact version exist in the configured official registry and the publication timestamp satisfies the configured minimum age; registry unavailability is reported as not verified and fails the check.
 - AC-005: Obvious misspellings, adjacent transpositions, and Unicode substitutions are blocked until a version-scoped exception with a non-empty reason is present in `.unicorn-hub/config.json`.
-- AC-006: Install scripts are denied by pnpm unless the exact package and version are explicitly allowed.
+- AC-006: Install scripts are denied by pnpm unless the exact package and version are explicitly allowed, and repository-controlled pnpmfile hooks are rejected before installation.
 - AC-007: Python-enabled profiles use `uv.lock` with `uv lock --check` and `uv sync --locked`, or a fully pinned hashed requirements lock installed using isolated pip, the official index, `--require-hashes`, and `--only-binary :all:`; unpinned requirements installs are not accepted.
 - AC-008: Bootstrap installs the checker and settings, exposes policy through `.unicorn-hub/config.json`, preserves consumer files unless `--force` authorizes replacement, and keeps generated examples synthetic.
 - AC-009: The checker is integrated into PR Guard without adding a new required check.
@@ -55,7 +55,7 @@ As a Python profile maintainer, I want either a locked `uv` workflow or a fully 
 - NS-002: A dependency name with a one-edit typo, adjacent transposition, or Unicode confusable is rejected without a matching version-scoped exception and reason.
 - NS-003: Git, URL, archive, tarball, local path, or unknown-registry dependency specifications are rejected.
 - NS-004: Registry downtime produces a fail-closed “not verified” result rather than a pass.
-- NS-005: An install-script package absent from the exact-version allowlist is blocked while an explicitly allowed package/version passes.
+- NS-005: An install-script package absent from the exact-version allowlist is blocked while an explicitly allowed package/version passes; repository pnpmfile hooks and hook settings are rejected before pnpm runs.
 - NS-006: A missing or manifest-stale pnpm lockfile is rejected.
 - NS-007: A Python requirements lock entry without a required hash is rejected.
 - NS-008: Non-Python profiles are not forced to adopt Python lock tooling.

--- a/specs/013-dependency-install-guard/spec.md
+++ b/specs/013-dependency-install-guard/spec.md
@@ -45,7 +45,7 @@ As a Python profile maintainer, I want either a locked `uv` workflow or a fully 
 - AC-004: Registry dependencies pass only when the exact package name and resolved exact version exist in the configured official registry and the publication timestamp satisfies the configured minimum age; registry unavailability is reported as not verified and fails the check.
 - AC-005: Obvious misspellings, adjacent transpositions, and Unicode substitutions are blocked until a version-scoped exception with a non-empty reason is present in `.unicorn-hub/config.json`.
 - AC-006: Install scripts are denied by pnpm unless the exact package and version are explicitly allowed, and repository-controlled pnpmfile hooks are rejected before installation.
-- AC-007: Python-enabled profiles use `uv.lock` with a no-build lock check and a locked dependency sync that neither builds nor installs the PR project inside the guard, or a fully pinned hashed requirements lock installed using isolated pip, the official index, `--require-hashes`, and `--only-binary :all:`; unpinned requirements installs are not accepted.
+- AC-007: Python-enabled profiles use `uv.lock` whose registry and artifact URLs are restricted to official PyPI hosts, with a no-build lock check and a locked dependency sync that neither builds nor installs the PR project inside the guard, or a fully pinned hashed requirements lock installed using isolated pip, the official index, `--require-hashes`, and `--only-binary :all:`; unpinned requirements installs are not accepted.
 - AC-008: Bootstrap installs the checker and settings, exposes policy through `.unicorn-hub/config.json`, preserves consumer files unless `--force` authorizes replacement, and keeps generated examples synthetic.
 - AC-009: The checker is integrated into PR Guard without adding a new required check.
 
@@ -59,6 +59,7 @@ As a Python profile maintainer, I want either a locked `uv` workflow or a fully 
 - NS-006: A missing or manifest-stale pnpm lockfile is rejected.
 - NS-007: A Python requirements lock entry without a required hash is rejected.
 - NS-008: Non-Python profiles are not forced to adopt Python lock tooling.
+- NS-009: A `uv.lock` wheel or source artifact URL outside the official PyPI distribution host is rejected before uv runs.
 
 ## Requirements
 

--- a/specs/013-dependency-install-guard/spec.md
+++ b/specs/013-dependency-install-guard/spec.md
@@ -1,0 +1,85 @@
+# Spec: Portable Dependency Install Guard
+
+## Goal
+
+Add a portable, fail-closed dependency installation policy that hardens Node and relevant Python profiles, catches obvious typosquatting risks, and remains a small repository-native guard rather than a reputation platform.
+
+## Scope
+
+In scope:
+
+- root and bootstrapped `pnpm-workspace.yaml` security settings
+- frozen pnpm lockfile enforcement in CI and repository checks
+- a dependency-policy checker installed into consumer repositories and invoked by the existing PR Guard
+- validation of newly added or changed direct Node dependencies against the official registry, publication time, obvious spelling/transposition and Unicode-confusable risks, and version-scoped exceptions
+- explicit pnpm install-script allowlisting
+- locked Python installation contracts for `python-service` and `telegram-bot`
+- profile-aware bootstrap configuration, documentation, and synthetic tests
+
+Out of scope:
+
+- GitHub security settings or branch-protection changes
+- a package popularity database, generalized reputation service, or new required status context
+- applying Python dependency rules to profiles that do not declare Python dependency management
+- global lifecycle-script enablement
+
+## User Stories
+
+### User Story 1
+
+As a repository maintainer, I want dependency additions to fail closed when their source, registry identity, exact version, age, or name safety cannot be verified, so that dependency installation remains reviewable and conservative.
+
+### User Story 2
+
+As an installing agent, I want Unicorn Hub to bootstrap the checker, policy configuration, and strict install contracts without silently overwriting consumer files, so that the protection is portable and predictable.
+
+### User Story 3
+
+As a Python profile maintainer, I want either a locked `uv` workflow or a fully hashed binary-only pip workflow, so that an unpinned `requirements.txt` is never represented as the safe default.
+
+## Acceptance Criteria
+
+- AC-001: Root and template pnpm settings retain `minimumReleaseAge: 10080` and enable `blockExoticSubdeps`, `trustPolicy: no-downgrade`, `strictDepBuilds`, and an explicit `allowBuilds` map without globally allowing lifecycle scripts.
+- AC-002: Node CI and repository validation fail when `pnpm-lock.yaml` is missing or stale and install only with `pnpm install --frozen-lockfile`.
+- AC-003: The existing `guard` job checks only new or changed direct dependency declarations and rejects Git, URL, tarball/archive, local, and unknown-registry sources.
+- AC-004: Registry dependencies pass only when the exact package name and resolved exact version exist in the configured official registry and the publication timestamp satisfies the configured minimum age; registry unavailability is reported as not verified and fails the check.
+- AC-005: Obvious misspellings, adjacent transpositions, and Unicode substitutions are blocked until a version-scoped exception with a non-empty reason is present in `.unicorn-hub/config.json`.
+- AC-006: Install scripts are denied by pnpm unless the exact package and version are explicitly allowed.
+- AC-007: Python-enabled profiles use `uv.lock` with `uv lock --check` and `uv sync --locked`, or a fully pinned hashed requirements lock installed using isolated pip, the official index, `--require-hashes`, and `--only-binary :all:`; unpinned requirements installs are not accepted.
+- AC-008: Bootstrap installs the checker and settings, exposes policy through `.unicorn-hub/config.json`, preserves consumer files unless `--force` authorizes replacement, and keeps generated examples synthetic.
+- AC-009: The checker is integrated into PR Guard without adding a new required check.
+
+## Negative Scenarios
+
+- NS-001: A nonexistent registry package or exact version is rejected.
+- NS-002: A dependency name with a one-edit typo, adjacent transposition, or Unicode confusable is rejected without a matching version-scoped exception and reason.
+- NS-003: Git, URL, archive, tarball, local path, or unknown-registry dependency specifications are rejected.
+- NS-004: Registry downtime produces a fail-closed “not verified” result rather than a pass.
+- NS-005: An install-script package absent from the exact-version allowlist is blocked while an explicitly allowed package/version passes.
+- NS-006: A missing or manifest-stale pnpm lockfile is rejected.
+- NS-007: A Python requirements lock entry without a required hash is rejected.
+- NS-008: Non-Python profiles are not forced to adopt Python lock tooling.
+
+## Requirements
+
+- FR-001: Keep the implementation dependency-free and use official registry metadata rather than a local popularity database.
+- FR-002: Compare direct dependency declarations between explicit base and head refs, including dependencies, devDependencies, optionalDependencies, and peerDependencies.
+- FR-003: Treat inability to verify required remote metadata as a blocking error with an explicit not-verified diagnostic.
+- FR-004: Scope exceptions to package name plus exact version and require a human-readable reason visible in repository configuration.
+- FR-005: Keep all policy defaults configurable through `.unicorn-hub/config.json` and profile output.
+- FR-006: Install all required checker scripts through the existing bootstrap allowlist and managed-file contract.
+- FR-007: Preserve consumer-owned collisions by default and refresh managed targets only under the established `--force` behavior.
+- FR-008: Use only neutral synthetic fixtures and mocked registry responses in tests.
+
+## Success Criteria
+
+- SC-001: Focused dependency-policy, workflow, baseline, and bootstrap tests cover every requested pass/fail scenario.
+- SC-002: `pnpm run preflight` passes, including sanitizer, baseline, workflow synchronization, syntax, and all tests.
+- SC-003: A final code review finds no unresolved blocking issues.
+- SC-004: The ready-for-review PR is published from a `codex/` branch with the required attribution trailers.
+
+## Assumptions
+
+- The project remains on pnpm 10.x, where the requested workspace policy keys are supported.
+- Exact registry verification may resolve an exact version from a lockfile when a direct manifest uses a semver range; direct non-registry protocols remain forbidden.
+- The official npm registry is the only supported Node registry for this portable policy.

--- a/specs/013-dependency-install-guard/spec.md
+++ b/specs/013-dependency-install-guard/spec.md
@@ -45,7 +45,7 @@ As a Python profile maintainer, I want either a locked `uv` workflow or a fully 
 - AC-004: Registry dependencies pass only when the exact package name and resolved exact version exist in the configured official registry and the publication timestamp satisfies the configured minimum age; registry unavailability is reported as not verified and fails the check.
 - AC-005: Obvious misspellings, adjacent transpositions, and Unicode substitutions are blocked until a version-scoped exception with a non-empty reason is present in `.unicorn-hub/config.json`.
 - AC-006: Install scripts are denied by pnpm unless the exact package and version are explicitly allowed, and repository-controlled pnpmfile hooks are rejected before installation.
-- AC-007: Python-enabled profiles use `uv.lock` with `uv lock --check` and `uv sync --locked`, or a fully pinned hashed requirements lock installed using isolated pip, the official index, `--require-hashes`, and `--only-binary :all:`; unpinned requirements installs are not accepted.
+- AC-007: Python-enabled profiles use `uv.lock` with a no-build lock check and a locked dependency sync that neither builds nor installs the PR project inside the guard, or a fully pinned hashed requirements lock installed using isolated pip, the official index, `--require-hashes`, and `--only-binary :all:`; unpinned requirements installs are not accepted.
 - AC-008: Bootstrap installs the checker and settings, exposes policy through `.unicorn-hub/config.json`, preserves consumer files unless `--force` authorizes replacement, and keeps generated examples synthetic.
 - AC-009: The checker is integrated into PR Guard without adding a new required check.
 

--- a/specs/013-dependency-install-guard/spec.md
+++ b/specs/013-dependency-install-guard/spec.md
@@ -41,7 +41,7 @@ As a Python profile maintainer, I want either a locked `uv` workflow or a fully 
 
 - AC-001: Root and template pnpm settings retain `minimumReleaseAge: 10080` and enable `blockExoticSubdeps`, `trustPolicy: no-downgrade`, `strictDepBuilds`, and an explicit `allowBuilds` map without globally allowing lifecycle scripts.
 - AC-002: Node CI and repository validation fail when `pnpm-lock.yaml` is missing or stale and install only with `pnpm install --frozen-lockfile`.
-- AC-003: The existing `guard` job checks only new or changed direct dependency declarations and rejects Git, URL, tarball/archive, local, and unknown-registry sources.
+- AC-003: The existing `guard` job checks only new or changed direct dependency declarations and rejects Git, URL, tarball/archive, local, unknown-registry, and pnpm dependency-graph rewrite sources.
 - AC-004: Registry dependencies pass only when the exact package name and resolved exact version exist in the configured official registry and the publication timestamp satisfies the configured minimum age; registry unavailability is reported as not verified and fails the check.
 - AC-005: Obvious misspellings, adjacent transpositions, and Unicode substitutions are blocked until a version-scoped exception with a non-empty reason is present in `.unicorn-hub/config.json`.
 - AC-006: Install scripts are denied by pnpm unless the exact package and version are explicitly allowed, and repository-controlled pnpmfile hooks are rejected before installation.
@@ -60,6 +60,7 @@ As a Python profile maintainer, I want either a locked `uv` workflow or a fully 
 - NS-007: A Python requirements lock entry without a required hash is rejected.
 - NS-008: Non-Python profiles are not forced to adopt Python lock tooling.
 - NS-009: A `uv.lock` wheel or source artifact URL outside the official PyPI distribution host is rejected before uv runs.
+- NS-010: pnpm `overrides`, `packageExtensions`, and `patchedDependencies` are rejected before pnpm runs, including settings nested in a package manifest.
 
 ## Requirements
 

--- a/specs/013-dependency-install-guard/tasks.md
+++ b/specs/013-dependency-install-guard/tasks.md
@@ -46,6 +46,7 @@
 - Prevent the trusted guard from building or installing PR-controlled Python project sources; uv checks and syncs run with `--no-build`, and sync omits the current project.
 - Reject uv wheel/source artifact URLs outside the exact official PyPI distribution host before running uv.
 - Reject pnpm graph-rewrite settings in both workspace policy and package manifests before running pnpm.
+- Keep independent pull-request CI installs script- and pnpmfile-free so dependency code cannot execute before the trusted guard completes.
 
 ### Verification Evidence
 

--- a/specs/013-dependency-install-guard/tasks.md
+++ b/specs/013-dependency-install-guard/tasks.md
@@ -43,6 +43,7 @@
 - Pin pnpm 10.34.5 because the official 10.x security advisories mark earlier releases vulnerable to repository-controlled registry/proxy request routing.
 - Reject unsupported pnpm policy escape hatches and noncanonical YAML indirection instead of expanding this checker into a general YAML policy engine.
 - Reject repository pnpmfile hooks and hook-location settings before any pnpm command; `--ignore-pnpmfile` remains defense in depth for the frozen-lock probe.
+- Prevent the trusted guard from building or installing PR-controlled Python project sources; uv checks and syncs run with `--no-build`, and sync omits the current project.
 
 ### Verification Evidence
 

--- a/specs/013-dependency-install-guard/tasks.md
+++ b/specs/013-dependency-install-guard/tasks.md
@@ -44,11 +44,12 @@
 - Reject unsupported pnpm policy escape hatches and noncanonical YAML indirection instead of expanding this checker into a general YAML policy engine.
 - Reject repository pnpmfile hooks and hook-location settings before any pnpm command; `--ignore-pnpmfile` remains defense in depth for the frozen-lock probe.
 - Prevent the trusted guard from building or installing PR-controlled Python project sources; uv checks and syncs run with `--no-build`, and sync omits the current project.
+- Reject uv wheel/source artifact URLs outside the exact official PyPI distribution host before running uv.
 
 ### Verification Evidence
 
-- `node --test tests/dependency-policy.test.mjs` — 33 focused dependency-policy tests passed.
-- `pnpm run preflight` — feature-memory, baseline, context, workflow sync, syntax, sanitizer, and all 94 tests passed after resolving the pnpmfile review finding.
+- `node --test tests/dependency-policy.test.mjs` — 34 focused dependency-policy tests passed.
+- `pnpm run preflight` — feature-memory, baseline, context, workflow sync, syntax, sanitizer, and all 95 tests passed after resolving the dependency-boundary review findings.
 - Synthetic bootstrap coverage confirms checker/settings installation, collision preservation, forced refresh, and Python-profile scoping.
 
 ### Known Issues

--- a/specs/013-dependency-install-guard/tasks.md
+++ b/specs/013-dependency-install-guard/tasks.md
@@ -42,11 +42,12 @@
 - Treat registry availability as required evidence for changed direct dependencies and fail closed when it cannot be obtained.
 - Pin pnpm 10.34.5 because the official 10.x security advisories mark earlier releases vulnerable to repository-controlled registry/proxy request routing.
 - Reject unsupported pnpm policy escape hatches and noncanonical YAML indirection instead of expanding this checker into a general YAML policy engine.
+- Reject repository pnpmfile hooks and hook-location settings before any pnpm command; `--ignore-pnpmfile` remains defense in depth for the frozen-lock probe.
 
 ### Verification Evidence
 
-- `node --test tests/dependency-policy.test.mjs` — 32 focused dependency-policy tests passed.
-- `pnpm run preflight` — feature-memory, baseline, context, workflow sync, syntax, sanitizer, and all 93 tests passed.
+- `node --test tests/dependency-policy.test.mjs` — 33 focused dependency-policy tests passed.
+- `pnpm run preflight` — feature-memory, baseline, context, workflow sync, syntax, sanitizer, and all 94 tests passed after resolving the pnpmfile review finding.
 - Synthetic bootstrap coverage confirms checker/settings installation, collision preservation, forced refresh, and Python-profile scoping.
 
 ### Known Issues

--- a/specs/013-dependency-install-guard/tasks.md
+++ b/specs/013-dependency-install-guard/tasks.md
@@ -45,11 +45,12 @@
 - Reject repository pnpmfile hooks and hook-location settings before any pnpm command; `--ignore-pnpmfile` remains defense in depth for the frozen-lock probe.
 - Prevent the trusted guard from building or installing PR-controlled Python project sources; uv checks and syncs run with `--no-build`, and sync omits the current project.
 - Reject uv wheel/source artifact URLs outside the exact official PyPI distribution host before running uv.
+- Reject pnpm graph-rewrite settings in both workspace policy and package manifests before running pnpm.
 
 ### Verification Evidence
 
-- `node --test tests/dependency-policy.test.mjs` — 34 focused dependency-policy tests passed.
-- `pnpm run preflight` — feature-memory, baseline, context, workflow sync, syntax, sanitizer, and all 95 tests passed after resolving the dependency-boundary review findings.
+- `node --test tests/dependency-policy.test.mjs` — 35 focused dependency-policy tests passed.
+- `pnpm run preflight` — feature-memory, baseline, context, workflow sync, syntax, sanitizer, and all 96 tests passed after resolving the dependency-boundary review findings.
 - Synthetic bootstrap coverage confirms checker/settings installation, collision preservation, forced refresh, and Python-profile scoping.
 
 ### Known Issues

--- a/specs/013-dependency-install-guard/tasks.md
+++ b/specs/013-dependency-install-guard/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Portable Dependency Install Guard
+
+## Setup
+
+- [x] T001 Read repository rules and required documentation in order.
+- [x] T002 Fetch GitHub state, inspect open PRs, and create `codex/dependency-install-guard` from fresh `origin/main`.
+- [x] T003 Inspect workspace settings, profiles, bootstrap behavior, workflows, existing supply-chain docs, and test conventions.
+- [x] T004 Create feature memory before implementation.
+- [x] T005 Confirm current pnpm, uv, and pip behavior from official documentation.
+
+## Implementation
+
+- [x] T006 Harden root and template pnpm workspace settings with exact install-script allowlisting.
+- [x] T007 Make Node lockfile checks and CI installation strictly frozen.
+- [x] T008 Implement the portable dependency-policy checker and configuration contract.
+- [x] T009 Integrate the checker into root/template PR Guard without a new status context.
+- [x] T010 Add profile-scoped uv and hashed-pip contracts for Python profiles.
+- [x] T011 Install the checker and policy settings through bootstrap while preserving consumer files without `--force`.
+- [x] T012 Update supply-chain, bootstrap, preflight, and CI documentation.
+
+## Verification
+
+- [x] T013 Add focused tests for registry identity/version/age, typo/transposition, Unicode substitution, forbidden sources, unknown registry, registry downtime, and scoped exceptions.
+- [x] T014 Add tests for install-script allowlisting, missing/stale Node lockfiles, and Python hash enforcement.
+- [x] T015 Add synthetic bootstrap tests for installed settings/scripts, Python profile scoping, and force/collision behavior.
+- [x] T016 Run focused tests and fix failures.
+- [x] T017 Run `pnpm run preflight` and confirm sanitizer, baseline, workflow sync, syntax, tests, and synthetic bootstrap pass.
+- [x] T018 Perform the requested code review and resolve all blocking findings.
+- [x] T019 Update verification evidence and process memory.
+- [x] T020 Commit with the required Codex co-author trailer, push, and publish a ready-for-review PR with the required PR attribution.
+
+## Process Memory
+
+### Dead Ends
+
+- The first frozen-lock probe used `--ignore-scripts` alone; review identified that pnpm still loads `.pnpmfile.cjs`, so the guard now also passes `--ignore-pnpmfile` and rejects unsafe request routing before invoking pnpm.
+
+### Decisions
+
+- Reuse the existing `guard` job rather than create another required status context.
+- Keep name protection heuristic and configurable; do not build or vendor a popularity/reputation database.
+- Treat registry availability as required evidence for changed direct dependencies and fail closed when it cannot be obtained.
+- Pin pnpm 10.34.5 because the official 10.x security advisories mark earlier releases vulnerable to repository-controlled registry/proxy request routing.
+- Reject unsupported pnpm policy escape hatches and noncanonical YAML indirection instead of expanding this checker into a general YAML policy engine.
+
+### Verification Evidence
+
+- `node --test tests/dependency-policy.test.mjs` — 32 focused dependency-policy tests passed.
+- `pnpm run preflight` — feature-memory, baseline, context, workflow sync, syntax, sanitizer, and all 93 tests passed.
+- Synthetic bootstrap coverage confirms checker/settings installation, collision preservation, forced refresh, and Python-profile scoping.
+
+### Known Issues
+
+- None accepted yet.

--- a/templates/.gitattributes
+++ b/templates/.gitattributes
@@ -9,6 +9,7 @@ scripts/ai-review-helpers.mjs          linguist-vendored
 scripts/ai-review-rerun.mjs            linguist-vendored
 scripts/apply-branch-protection.mjs    linguist-vendored
 scripts/check-context-budget.mjs       linguist-vendored
+scripts/check-dependency-policy.mjs    linguist-vendored
 scripts/check-feature-memory.mjs       linguist-vendored
 scripts/check-repo-baseline.mjs        linguist-vendored
 scripts/new-worktree.mjs               linguist-vendored

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.34.5
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -27,16 +29,11 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
-      - name: Install dependencies
-        run: |
-          if [ -f pnpm-lock.yaml ]; then
-            pnpm install --frozen-lockfile
-          else
-            pnpm install --no-frozen-lockfile
-          fi
-
       - name: Run repository baseline
         run: pnpm run check:repo
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests if present
         run: pnpm run --if-present test

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm run check:repo
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts --ignore-pnpmfile
 
       - name: Run tests if present
         run: pnpm run --if-present test

--- a/templates/.github/workflows/pr-guard.yml
+++ b/templates/.github/workflows/pr-guard.yml
@@ -32,6 +32,15 @@ jobs:
           path: .gate-trusted
           fetch-depth: 1
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.34.5
+
+      - name: Setup uv for Python lock verification
+        if: ${{ hashFiles('uv.lock') != '' }}
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
       - name: Resolve diff refs
         shell: bash
         env:
@@ -77,4 +86,13 @@ jobs:
           else
             echo "::warning::Trusted baseline script missing on default branch; using PR script for first-install bootstrap only."
             node scripts/check-repo-baseline.mjs --target "$GITHUB_WORKSPACE"
+          fi
+
+      - name: Enforce dependency policy
+        run: |
+          if [ -f .gate-trusted/scripts/check-dependency-policy.mjs ]; then
+            node .gate-trusted/scripts/check-dependency-policy.mjs --sync-python --target "$GITHUB_WORKSPACE" "$BASE_REF" "$HEAD_REF"
+          else
+            echo "::warning::Trusted dependency policy script missing on default branch; using PR script for first-install bootstrap only."
+            node scripts/check-dependency-policy.mjs --sync-python --target "$GITHUB_WORKSPACE" "$BASE_REF" "$HEAD_REF"
           fi

--- a/templates/.unicorn-hub/config.json
+++ b/templates/.unicorn-hub/config.json
@@ -5,5 +5,17 @@
   "requiredChecks": ["baseline-checks", "guard", "AI Review"],
   "defaultBaseBranch": "main",
   "defaultImplementationAgent": "claude",
-  "defaultReviewAgent": "codex"
+  "defaultReviewAgent": "codex",
+  "dependencyPolicy": {
+    "node": {
+      "minimumReleaseAgeMinutes": 10080,
+      "registryTimeoutMilliseconds": 10000,
+      "protectedPackageNames": [],
+      "typosquatExceptions": []
+    },
+    "python": {
+      "enabled": false,
+      "requirementsLockFile": "requirements.lock"
+    }
+  }
 }

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -12,6 +12,7 @@
 - Product-code PRs must include one complete `specs/<feature-id>/` folder with `spec.md`, `plan.md`, and `tasks.md`.
 - Acceptance criteria need concrete verification evidence before merge.
 - Run `pnpm run preflight` or the project-equivalent command before pushing.
+- Keep dependency installs locked; review direct dependency and exact-version install-script policy changes in the PR diff.
 - Never push directly to the default branch or merge with missing, queued, red, or stale required checks.
 - Do not put secrets, private URLs, production identifiers, or personal paths in docs, specs, examples, or templates.
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -13,6 +13,7 @@ This repository uses a portable multi-agent development workflow:
 - Claude-specific guidance in `CLAUDE.md`
 - local preflight before push
 - GitHub CI, PR Guard, and AI Review gates
+- frozen dependency locks and direct-dependency policy in the existing PR Guard
 
 ## First Setup After Bootstrap
 
@@ -31,12 +32,22 @@ If project docs already exist, use the same protocol to review and refresh them.
 
 ```bash
 pnpm run preflight
+pnpm run check:dependencies -- <base-ref> <head-ref>
 pnpm run worktree:new -- --slug 001-example
 pnpm run pr:publish
 ```
 
 `pnpm run pr:publish` opens a ready-for-review pull request by default. Use
 `pnpm run pr:publish -- --draft` only when a draft is intentional.
+
+Node installs require a current `pnpm-lock.yaml` and use
+`pnpm install --frozen-lockfile`. Review install-script permissions in the
+exact-version `allowBuilds` map in `pnpm-workspace.yaml`. Dependency-policy
+settings and reviewed typosquat exceptions live under `dependencyPolicy` in
+`.unicorn-hub/config.json`. Python-enabled profiles use `uv lock --check` plus
+`uv sync --locked`, or a fully pinned and hashed `requirements.lock` installed
+with isolated pip, the official index, `--require-hashes`, and
+`--only-binary :all:`.
 
 ## Required PR Checks
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -41,14 +41,16 @@ pnpm run pr:publish
 `pnpm run pr:publish -- --draft` only when a draft is intentional.
 
 Node installs require a current `pnpm-lock.yaml` and use
-`pnpm install --frozen-lockfile`. Review install-script permissions in the
-exact-version `allowBuilds` map in `pnpm-workspace.yaml`. Dependency-policy
-settings and reviewed typosquat exceptions live under `dependencyPolicy` in
-`.unicorn-hub/config.json`. Repository pnpmfile hooks and custom `pnpmfile` or
-`global-pnpmfile` settings are not supported. Python-enabled profiles use
-`uv lock --check` plus `uv sync --locked`, or a fully pinned and hashed
-`requirements.lock` installed with isolated pip, the official index,
-`--require-hashes`, and `--only-binary :all:`.
+`pnpm install --frozen-lockfile`; pull request CI adds `--ignore-scripts` and
+`--ignore-pnpmfile` so dependency code cannot run before trusted policy review.
+Review install-script permissions in the exact-version `allowBuilds` map in
+`pnpm-workspace.yaml`. Dependency-policy settings and reviewed typosquat
+exceptions live under `dependencyPolicy` in `.unicorn-hub/config.json`.
+Repository pnpmfile hooks and custom `pnpmfile` or `global-pnpmfile` settings
+are not supported. Python-enabled profiles use `uv lock --check` plus
+`uv sync --locked`, or a fully pinned and hashed `requirements.lock` installed
+with isolated pip, the official index, `--require-hashes`, and
+`--only-binary :all:`.
 
 ## Required PR Checks
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -44,10 +44,11 @@ Node installs require a current `pnpm-lock.yaml` and use
 `pnpm install --frozen-lockfile`. Review install-script permissions in the
 exact-version `allowBuilds` map in `pnpm-workspace.yaml`. Dependency-policy
 settings and reviewed typosquat exceptions live under `dependencyPolicy` in
-`.unicorn-hub/config.json`. Python-enabled profiles use `uv lock --check` plus
-`uv sync --locked`, or a fully pinned and hashed `requirements.lock` installed
-with isolated pip, the official index, `--require-hashes`, and
-`--only-binary :all:`.
+`.unicorn-hub/config.json`. Repository pnpmfile hooks and custom `pnpmfile` or
+`global-pnpmfile` settings are not supported. Python-enabled profiles use
+`uv lock --check` plus `uv sync --locked`, or a fully pinned and hashed
+`requirements.lock` installed with isolated pip, the official index,
+`--require-hashes`, and `--only-binary :all:`.
 
 ## Required PR Checks
 

--- a/templates/docs_project/project/devops/ai-pr-workflow.md
+++ b/templates/docs_project/project/devops/ai-pr-workflow.md
@@ -7,6 +7,14 @@ The active required-check list is `.unicorn-hub/config.json` (`requiredChecks`);
 
 PRs are merge-ready only when all checks are green, blocking findings are resolved, docs/specs are updated, and no conflicts remain.
 
+The existing `guard` context also runs `scripts/check-dependency-policy.mjs`.
+Changed direct dependencies must resolve through a current pnpm lock and verify
+against the official registry; exotic sources, unreviewed similar/Unicode names,
+and undeclared install scripts fail closed. Python-enabled profiles must use a
+current `uv.lock` or a fully pinned hashed requirements lock. Narrow reviewed
+exceptions belong in `.unicorn-hub/config.json` so their version and reason are
+visible in the PR diff.
+
 `AI Review` is a required check and is event-driven. It fails quickly when a
 trusted current-head review request or review evidence is missing. A trusted
 human review trigger records the current head SHA, then review-result events

--- a/templates/package.json
+++ b/templates/package.json
@@ -2,13 +2,14 @@
   "name": "<PACKAGE_NAME>",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.34.5",
   "engines": {
     "node": ">=20",
-    "pnpm": ">=10.16"
+    "pnpm": ">=10.34.5"
   },
   "scripts": {
     "check:context": "node scripts/check-context-budget.mjs",
+    "check:dependencies": "node scripts/check-dependency-policy.mjs",
     "check:feature-memory": "node scripts/check-feature-memory.mjs",
     "check:repo": "node scripts/check-repo-baseline.mjs",
     "preflight": "node scripts/check-feature-memory.mjs --worktree && pnpm run check:repo && pnpm run check:context -- --local-preflight && pnpm run check:context -- --worktree",

--- a/templates/pnpm-lock.yaml
+++ b/templates/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/templates/pnpm-workspace.yaml
+++ b/templates/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 minimumReleaseAge: 10080
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+strictDepBuilds: true
+allowBuilds: {}
 packages:
   - .

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -56,10 +56,13 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
     ".github/workflows/ai-review-rerun.yml",
     "scripts/ai-command-policy.mjs",
     "scripts/ai-review-rerun.mjs",
+    "scripts/check-dependency-policy.mjs",
     "scripts/check-context-budget.mjs",
     "scripts/check-feature-memory.mjs",
     "scripts/publish-branch.mjs",
-    ".unicorn-hub/config.json"
+    ".unicorn-hub/config.json",
+    "pnpm-workspace.yaml",
+    "pnpm-lock.yaml"
   ]) {
     assert.equal(existsSync(join(target, path)), true, `${path} should exist`);
   }
@@ -100,9 +103,13 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
 
   const config = JSON.parse(readFileSync(join(target, ".unicorn-hub/config.json"), "utf8"));
   assert.equal(config.profile, "generic");
+  assert.equal(config.dependencyPolicy.node.minimumReleaseAgeMinutes, 10080);
+  assert.deepEqual(config.dependencyPolicy.node.typosquatExceptions, []);
+  assert.equal(config.dependencyPolicy.python.enabled, false);
 
   const packageJson = JSON.parse(readFileSync(join(target, "package.json"), "utf8"));
   assert.equal(packageJson.scripts["check:context"], "node scripts/check-context-budget.mjs");
+  assert.equal(packageJson.scripts["check:dependencies"], "node scripts/check-dependency-policy.mjs");
   assert.match(packageJson.scripts.preflight, /pnpm run check:context -- --local-preflight && pnpm run check:context -- --worktree/);
   assert.equal(
     readFileSync(join(target, "scripts/publish-branch.mjs"), "utf8"),
@@ -113,6 +120,14 @@ test("bootstrap installs generic blueprint into a synthetic target", () => {
   const prGuard = readFileSync(join(target, ".github/workflows/pr-guard.yml"), "utf8");
   assert.match(prGuard, /Validate context budget/);
   assert.match(prGuard, /check-context-budget\.mjs --target "\$GITHUB_WORKSPACE" "\$BASE_REF" "\$HEAD_REF"/);
+  assert.match(prGuard, /check-dependency-policy\.mjs --sync-python/);
+
+  const workspacePolicy = readFileSync(join(target, "pnpm-workspace.yaml"), "utf8");
+  assert.match(workspacePolicy, /^minimumReleaseAge: 10080$/m);
+  assert.match(workspacePolicy, /^blockExoticSubdeps: true$/m);
+  assert.match(workspacePolicy, /^trustPolicy: no-downgrade$/m);
+  assert.match(workspacePolicy, /^strictDepBuilds: true$/m);
+  assert.match(workspacePolicy, /^allowBuilds: \{\}$/m);
 
   const specTemplate = readFileSync(join(target, ".specify/templates/spec-template.md"), "utf8");
   assert.match(specTemplate, /## Goal/);
@@ -142,6 +157,72 @@ test("bootstrap --dry-run announces a dry run instead of next steps", () => {
   assert.match(output, /Re-run without --dry-run to apply\./);
   assert.doesNotMatch(output, /\nNext:\n/);
   assert.equal(existsSync(join(target, "AGENTS.md")), false, "dry run must not write files");
+});
+
+test("bootstrap preserves dependency policy consumer files unless --force is used", () => {
+  const target = mkdtempSync(join(tmpdir(), "unicorn-dependency-collision-"));
+  mkdirSync(join(target, "scripts"), { recursive: true });
+  const consumerScript = "console.log('consumer dependency policy');\n";
+  const consumerWorkspace = "packages:\n  - consumer-package\n";
+  writeFileSync(join(target, "scripts/check-dependency-policy.mjs"), consumerScript);
+  writeFileSync(join(target, "pnpm-workspace.yaml"), consumerWorkspace);
+
+  const first = run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Synthetic Collision"
+  ]);
+  assert.match(first, /^skip\s+scripts\/check-dependency-policy\.mjs$/m);
+  assert.match(first, /^skip\s+pnpm-workspace\.yaml$/m);
+  assert.equal(readFileSync(join(target, "scripts/check-dependency-policy.mjs"), "utf8"), consumerScript);
+  assert.equal(readFileSync(join(target, "pnpm-workspace.yaml"), "utf8"), consumerWorkspace);
+
+  const forced = run([
+    "scripts/bootstrap-repo.mjs",
+    "--source",
+    root,
+    "--target",
+    target,
+    "--profile",
+    "generic",
+    "--project-name",
+    "Synthetic Collision",
+    "--force"
+  ]);
+  assert.match(forced, /^overwrite\s+scripts\/check-dependency-policy\.mjs$/m);
+  assert.match(forced, /^overwrite\s+pnpm-workspace\.yaml$/m);
+  assert.equal(
+    readFileSync(join(target, "scripts/check-dependency-policy.mjs"), "utf8"),
+    readFileSync(join(root, "scripts/check-dependency-policy.mjs"), "utf8")
+  );
+  assert.match(readFileSync(join(target, "pnpm-workspace.yaml"), "utf8"), /strictDepBuilds: true/);
+});
+
+test("Python profiles receive locked dependency contracts without affecting generic", () => {
+  for (const profile of ["python-service", "telegram-bot"]) {
+    const target = mkdtempSync(join(tmpdir(), `unicorn-${profile}-policy-`));
+    run([
+      "scripts/bootstrap-repo.mjs",
+      "--source",
+      root,
+      "--target",
+      target,
+      "--profile",
+      profile,
+      "--project-name",
+      `Synthetic ${profile}`
+    ]);
+    const config = JSON.parse(readFileSync(join(target, ".unicorn-hub/config.json"), "utf8"));
+    assert.equal(config.dependencyPolicy.python.enabled, true, profile);
+    assert.equal(config.commands.install, "uv lock --check && uv sync --locked", profile);
+    assert.doesNotMatch(config.commands.install, /pip install -r requirements.*\.txt/, profile);
+  }
 });
 
 test("bootstrap idempotent re-run reports nothing new to review", () => {
@@ -437,6 +518,12 @@ test("bootstrap into pre-existing package.json preserves user-defined packageMan
     packageJson.packageManager,
     "pnpm@9.0.0",
     "user-defined packageManager must outrank template defaults"
+  );
+
+  assert.throws(
+    () => run(["scripts/check-repo-baseline.mjs", "--target", target]),
+    /Command failed/,
+    "preserved pnpm versions older than the security-policy minimum must fail baseline until explicitly upgraded"
   );
 });
 

--- a/tests/dependency-policy.test.mjs
+++ b/tests/dependency-policy.test.mjs
@@ -706,7 +706,7 @@ test("Python lock policy applies only to enabled or Python profiles", () => {
   assert.match(validatePythonContract(root, enabled, noOpCommand).join("\n"), /requires uv.lock or hashed requirements.lock/);
 });
 
-test("Python uv contract checks and syncs the locked project", () => {
+test("Python uv contract checks and syncs locked dependencies without building PR sources", () => {
   const root = mkdtempSync(join(tmpdir(), "unicorn-python-uv-"));
   writeFileSync(join(root, "pyproject.toml"), "[project]\nname = \"synthetic-python\"\nversion = \"0.1.0\"\n");
   writeFileSync(join(root, "uv.lock"), "version = 1\n");
@@ -719,8 +719,8 @@ test("Python uv contract checks and syncs the locked project", () => {
   assert.deepEqual(validatePythonContract(root, config, capture), []);
   assert.deepEqual(syncPythonContract(root, config, capture), []);
   assert.deepEqual(calls, [
-    ["uv", "lock", "--check"],
-    ["uv", "sync", "--locked"]
+    ["uv", "lock", "--check", "--no-build"],
+    ["uv", "sync", "--locked", "--no-install-project", "--no-build"]
   ]);
 });
 

--- a/tests/dependency-policy.test.mjs
+++ b/tests/dependency-policy.test.mjs
@@ -1,7 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -15,6 +24,7 @@ import {
   syncPythonContract,
   validateHashedRequirements,
   validateLockfileRegistries,
+  validatePackageManifestPolicy,
   validatePythonContract,
   validateWorkspacePolicy,
   verifyChangedDependency
@@ -401,6 +411,39 @@ test("workspace policy rejects alternate registries, escape hatches, and YAML sc
     validateWorkspacePolicy(`${workspace()}"registry": https:\/\/packages.example.invalid\/\n`).errors.join("\n"),
     /canonical unquoted/
   );
+  for (const setting of ["overrides", "packageExtensions", "patchedDependencies", "onlyBuiltDependencies"]) {
+    assert.match(
+      validateWorkspacePolicy(`${workspace()}${setting}: {}\n`).errors.join("\n"),
+      new RegExp(`${setting} is not supported`)
+    );
+  }
+});
+
+test("package manifest pnpm policy and graph rewrites are rejected before pnpm runs", async () => {
+  assert.deepEqual(validatePackageManifestPolicy({ name: "synthetic", pnpm: {} }), []);
+  for (const setting of ["overrides", "packageExtensions", "patchedDependencies", "onlyBuiltDependencies"]) {
+    const root = syntheticRepo();
+    const manifestPath = join(root, "package.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.pnpm = { [setting]: { "synthetic-package": "1.2.3" } };
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    git(root, ["add", "package.json"]);
+    git(root, ["commit", "-qm", "add graph rewrite"]);
+    let commandCalls = 0;
+    const errors = await runDependencyPolicy({
+      root,
+      baseRef: "HEAD~1",
+      headRef: "HEAD",
+      runCommand: () => {
+        commandCalls += 1;
+        return "";
+      },
+      fetchImpl: async () => response(200, {}),
+      now: NOW
+    });
+    assert.match(errors.join("\n"), new RegExp(`pnpm\\.${setting} is not supported`));
+    assert.equal(commandCalls, 0, setting);
+  }
 });
 
 test("new allowBuilds permission must match a verified install script", async () => {

--- a/tests/dependency-policy.test.mjs
+++ b/tests/dependency-policy.test.mjs
@@ -455,6 +455,50 @@ test("project npmrc cannot override dependency build policy", async () => {
   assert.equal(commandCalls, 0);
 });
 
+test("repository pnpm hook files and settings are rejected before pnpm runs", async () => {
+  for (const hookFile of [".pnpmfile.cjs", ".pnpmfile.mjs"]) {
+    const root = syntheticRepo();
+    writeFileSync(join(root, hookFile), "module.exports = { hooks: {} };\n");
+    git(root, ["add", hookFile]);
+    git(root, ["commit", "-qm", "add pnpm hook"]);
+    let commandCalls = 0;
+    const errors = await runDependencyPolicy({
+      root,
+      baseRef: "HEAD~1",
+      headRef: "HEAD",
+      runCommand: () => {
+        commandCalls += 1;
+        return "";
+      },
+      fetchImpl: async () => response(200, {}),
+      now: NOW
+    });
+    assert.match(errors.join("\n"), new RegExp(`${hookFile.replaceAll(".", "\\.")}.*not supported`));
+    assert.equal(commandCalls, 0, hookFile);
+  }
+
+  for (const setting of ["pnpmfile=.pnpm/custom.cjs", "global-pnpmfile=.pnpm/global.cjs"]) {
+    const root = syntheticRepo({ npmrc: `${setting}\n` });
+    let commandCalls = 0;
+    const errors = await runDependencyPolicy({
+      root,
+      baseRef: "HEAD~1",
+      headRef: "HEAD",
+      runCommand: () => {
+        commandCalls += 1;
+        return "";
+      },
+      fetchImpl: async () => response(200, {}),
+      now: NOW
+    });
+    assert.match(errors.join("\n"), /pnpm hook setting/);
+    assert.equal(commandCalls, 0, setting);
+  }
+
+  const workspaceErrors = validateWorkspacePolicy(`${workspace()}pnpmfile: .pnpm/custom.cjs\n`).errors;
+  assert.match(workspaceErrors.join("\n"), /pnpmfile is not supported/);
+});
+
 test("invalid numeric policy configuration fails instead of weakening checks", async () => {
   const root = syntheticRepo({
     config: policyConfig({

--- a/tests/dependency-policy.test.mjs
+++ b/tests/dependency-policy.test.mjs
@@ -746,6 +746,39 @@ test("Python uv contract rejects direct Git, URL, and local sources", () => {
   assert.match(validatePythonContract(lockRoot, config, noOpCommand).join("\n"), /uv\.lock contains a forbidden/);
 });
 
+test("Python uv contract accepts only official PyPI artifact URLs", () => {
+  const config = policyConfig({
+    profile: "python-service",
+    dependencyPolicy: { node: {}, python: { enabled: true, requirementsLockFile: "requirements.lock" } }
+  });
+  const root = mkdtempSync(join(tmpdir(), "unicorn-python-uv-artifact-"));
+  writeFileSync(join(root, "pyproject.toml"), "[project]\nname = \"synthetic-python\"\nversion = \"0.1.0\"\n");
+  const lockWithUrl = (url) => [
+    "version = 1",
+    "[[package]]",
+    "name = \"synthetic-package\"",
+    "version = \"1.2.3\"",
+    "source = { registry = \"https://pypi.org/simple\" }",
+    `wheels = [{ url = "${url}", hash = "sha256:${"a".repeat(64)}", size = 1 }]`,
+    ""
+  ].join("\n");
+
+  writeFileSync(join(root, "uv.lock"), lockWithUrl("https://packages.example.invalid/synthetic.whl"));
+  let commandCalls = 0;
+  const rejected = validatePythonContract(root, config, () => {
+    commandCalls += 1;
+  });
+  assert.match(rejected.join("\n"), /non-official Python artifact URL/);
+  assert.equal(commandCalls, 0);
+
+  writeFileSync(join(root, "uv.lock"), lockWithUrl(
+    "https://files.pythonhosted.org/packages/aa/bb/synthetic_package-1.2.3-py3-none-any.whl"
+  ));
+  const calls = [];
+  assert.deepEqual(validatePythonContract(root, config, (command, args) => calls.push([command, ...args])), []);
+  assert.deepEqual(calls, [["uv", "lock", "--check", "--no-build"]]);
+});
+
 test("hashed Python contract uses require-hashes and binary-only install", () => {
   const root = mkdtempSync(join(tmpdir(), "unicorn-python-hashes-"));
   writeFileSync(

--- a/tests/dependency-policy.test.mjs
+++ b/tests/dependency-policy.test.mjs
@@ -1,0 +1,751 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  changedDirectDependencies,
+  classifyDependencySpecifier,
+  findSuspiciousName,
+  parseNpmrc,
+  parsePnpmLockImporters,
+  parseWorkspacePolicy,
+  runDependencyPolicy,
+  syncPythonContract,
+  validateHashedRequirements,
+  validateLockfileRegistries,
+  validatePythonContract,
+  validateWorkspacePolicy,
+  verifyChangedDependency
+} from "../scripts/check-dependency-policy.mjs";
+
+const NOW = Date.parse("2026-01-20T00:00:00Z");
+const OLD_PUBLICATION = "2025-01-01T00:00:00Z";
+
+function response(status, body = {}) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async json() {
+      return body;
+    }
+  };
+}
+
+function metadata(name, version, options = {}) {
+  return {
+    name,
+    versions: {
+      [version]: {
+        name,
+        version,
+        ...(options.scripts ? { scripts: options.scripts } : {})
+      }
+    },
+    time: { [version]: options.publishedAt || OLD_PUBLICATION }
+  };
+}
+
+function workspace(allowBuilds = []) {
+  const entries = allowBuilds.map((matcher) => `  "${matcher}": true`).join("\n");
+  return [
+    "minimumReleaseAge: 10080",
+    "blockExoticSubdeps: true",
+    "trustPolicy: no-downgrade",
+    "strictDepBuilds: true",
+    entries ? `allowBuilds:\n${entries}` : "allowBuilds: {}",
+    "packages:",
+    "  - .",
+    ""
+  ].join("\n");
+}
+
+function lockfile(dependencies = {}) {
+  const names = Object.keys(dependencies);
+  const dependencyBlock = names.length === 0
+    ? "  .: {}"
+    : [
+        "  .:",
+        "    dependencies:",
+        ...names.flatMap((name) => [
+          `      ${name}:`,
+          `        specifier: ${dependencies[name].specifier}`,
+          `        version: ${dependencies[name].version}`
+        ])
+      ].join("\n");
+  return [
+    "lockfileVersion: '9.0'",
+    "",
+    "settings:",
+    "  autoInstallPeers: true",
+    "  excludeLinksFromLockfile: false",
+    "",
+    "importers:",
+    "",
+    dependencyBlock,
+    ""
+  ].join("\n");
+}
+
+function policyConfig(overrides = {}) {
+  return {
+    docsDir: "docs",
+    specsDir: "specs",
+    profile: "generic",
+    dependencyPolicy: {
+      node: {
+        minimumReleaseAgeMinutes: 10080,
+        registryTimeoutMilliseconds: 1000,
+        protectedPackageNames: [],
+        typosquatExceptions: []
+      },
+      python: { enabled: false, requirementsLockFile: "requirements.lock" }
+    },
+    ...overrides
+  };
+}
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function syntheticRepo({
+  baseDependencies = {},
+  baseLockedVersions = {},
+  headDependencies = {},
+  npmrc = "",
+  includeLock = true,
+  headLockedVersions = {},
+  config = policyConfig(),
+  headConfig = config,
+  baseWorkspace = workspace(),
+  headWorkspace = baseWorkspace
+} = {}) {
+  const root = mkdtempSync(join(tmpdir(), "unicorn-dependency-policy-"));
+  mkdirSync(join(root, ".unicorn-hub"), { recursive: true });
+  mkdirSync(join(root, "docs"), { recursive: true });
+  writeFileSync(join(root, ".unicorn-hub/config.json"), `${JSON.stringify(config, null, 2)}\n`);
+  writeFileSync(join(root, "pnpm-workspace.yaml"), baseWorkspace);
+  writeFileSync(join(root, "package.json"), `${JSON.stringify({ name: "synthetic", dependencies: baseDependencies }, null, 2)}\n`);
+  writeFileSync(join(root, "pnpm-lock.yaml"), lockfile(Object.fromEntries(
+    Object.entries(baseDependencies).map(([name, specifier]) => [
+      name,
+      { specifier, version: baseLockedVersions[name] || specifier }
+    ])
+  )));
+  git(root, ["init", "-q"]);
+  git(root, ["config", "user.email", "synthetic@example.invalid"]);
+  git(root, ["config", "user.name", "Synthetic Test"]);
+  git(root, ["add", "."]);
+  git(root, ["commit", "-qm", "base"]);
+
+  writeFileSync(join(root, "package.json"), `${JSON.stringify({ name: "synthetic", dependencies: headDependencies }, null, 2)}\n`);
+  writeFileSync(join(root, ".unicorn-hub/config.json"), `${JSON.stringify(headConfig, null, 2)}\n`);
+  writeFileSync(join(root, "pnpm-workspace.yaml"), headWorkspace);
+  writeFileSync(join(root, "head-marker.txt"), "synthetic head\n");
+  if (includeLock) {
+    writeFileSync(join(root, "pnpm-lock.yaml"), lockfile(Object.fromEntries(
+      Object.entries(headDependencies).map(([name, specifier]) => [
+        name,
+        { specifier, version: headLockedVersions[name] || specifier }
+      ])
+    )));
+  } else {
+    unlinkSync(join(root, "pnpm-lock.yaml"));
+  }
+  if (npmrc) writeFileSync(join(root, ".npmrc"), npmrc);
+  git(root, ["add", "-A"]);
+  git(root, ["commit", "-qm", "head"]);
+  return root;
+}
+
+function noOpCommand() {
+  return "";
+}
+
+test("valid official-registry package and exact version pass", async () => {
+  let acceptHeader = "";
+  const errors = await verifyChangedDependency({
+    entry: { name: "lodash", specifier: "^4.17.21", field: "dependencies" },
+    version: "4.17.21",
+    registry: "https://registry.npmjs.org/",
+    workspacePolicy: parseWorkspacePolicy(workspace()),
+    fetchImpl: async (_url, options) => {
+      acceptHeader = options.headers.accept;
+      return response(200, metadata("lodash", "4.17.21"));
+    },
+    now: NOW
+  });
+  assert.deepEqual(errors, []);
+  assert.equal(acceptHeader, "application/json", "full packument metadata is required for time and scripts");
+});
+
+test("nonexistent registry name or exact version is blocked", async () => {
+  const common = {
+    entry: { name: "synthetic-package", specifier: "1.0.0", field: "dependencies" },
+    version: "1.0.0",
+    registry: "https://registry.npmjs.org/",
+    workspacePolicy: parseWorkspacePolicy(workspace()),
+    now: NOW
+  };
+  assert.match((await verifyChangedDependency({ ...common, fetchImpl: async () => response(404) })).join("\n"), /does not exist/);
+  assert.match(
+    (await verifyChangedDependency({ ...common, fetchImpl: async () => response(200, metadata("synthetic-package", "2.0.0")) })).join("\n"),
+    /version .* does not exist/
+  );
+});
+
+test("one-edit typo and adjacent transposition are blocked", () => {
+  assert.match(findSuspiciousName("lodasx").message, /protected name 'lodash'/);
+  assert.match(findSuspiciousName("lodahs").message, /adjacent transposition/);
+  assert.match(findSuspiciousName("@angualr/core", ["@angular/core"]).message, /protected name '@angular\/core'/);
+});
+
+test("direct dependency changes remain distinct across manifest fields", () => {
+  const changes = changedDirectDependencies(
+    { dependencies: { lodash: "4.17.21" }, devDependencies: { lodash: "4.17.21" } },
+    { dependencies: { lodash: "git+https://example.invalid/lodash.git" }, devDependencies: { lodash: "4.17.21" } }
+  );
+  assert.deepEqual(changes, [{
+    name: "lodash",
+    specifier: "git+https://example.invalid/lodash.git",
+    field: "dependencies"
+  }]);
+});
+
+test("Unicode confusable substitution is blocked", () => {
+  const cyrillicA = "lod\u0430sh";
+  assert.equal(findSuspiciousName(cyrillicA).kind, "unicode");
+});
+
+test("Git, URL, tarball, archive, and local dependencies are blocked", () => {
+  for (const specifier of [
+    "git+https://example.invalid/repo.git",
+    "https://example.invalid/pkg.tgz",
+    "file:../pkg",
+    "../pkg",
+    "package.zip"
+  ]) {
+    assert.equal(classifyDependencySpecifier(specifier).allowed, false, specifier);
+  }
+});
+
+test("unknown npm registry is blocked before metadata lookup", async () => {
+  const root = syntheticRepo({
+    headDependencies: { lodash: "4.17.21" },
+    npmrc: "registry=https://packages.example.invalid/\n"
+  });
+  let fetchCalls = 0;
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: noOpCommand,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return response(200, metadata("lodash", "4.17.21"));
+    },
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /unknown .*registry/);
+  assert.equal(fetchCalls, 0);
+  assert.equal(parseNpmrc("registry=https://packages.example.invalid/").default, "https://packages.example.invalid/");
+});
+
+test("registry unavailability is reported as not verified and fails closed", async () => {
+  const errors = await verifyChangedDependency({
+    entry: { name: "lodash", specifier: "4.17.21", field: "dependencies" },
+    version: "4.17.21",
+    registry: "https://registry.npmjs.org/",
+    workspacePolicy: parseWorkspacePolicy(workspace()),
+    fetchImpl: async () => {
+      throw new Error("synthetic registry outage");
+    },
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /not verified.*synthetic registry outage/);
+});
+
+test("newly published registry version is blocked by release age", async () => {
+  const errors = await verifyChangedDependency({
+    entry: { name: "synthetic-package", specifier: "1.0.0", field: "dependencies" },
+    version: "1.0.0",
+    registry: "https://registry.npmjs.org/",
+    workspacePolicy: parseWorkspacePolicy(workspace()),
+    fetchImpl: async () => response(200, metadata("synthetic-package", "1.0.0", {
+      publishedAt: "2026-01-19T23:00:00Z"
+    })),
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /younger than the 10080-minute minimum release age/);
+});
+
+test("unknown install script is blocked and exact-version allowBuilds passes", async () => {
+  const common = {
+    entry: { name: "synthetic-builder", specifier: "1.2.3", field: "dependencies" },
+    version: "1.2.3",
+    registry: "https://registry.npmjs.org/",
+    fetchImpl: async () => response(200, metadata("synthetic-builder", "1.2.3", { scripts: { install: "node build.js" } })),
+    now: NOW
+  };
+  const blocked = await verifyChangedDependency({ ...common, workspacePolicy: parseWorkspacePolicy(workspace()) });
+  assert.match(blocked.join("\n"), /not allowed by exact-version allowBuilds/);
+
+  const allowed = await verifyChangedDependency({
+    ...common,
+    workspacePolicy: parseWorkspacePolicy(workspace(["synthetic-builder@1.2.3"]))
+  });
+  assert.deepEqual(allowed, []);
+});
+
+test("version-scoped typo exception requires a reason and permits reviewed name", async () => {
+  const common = {
+    entry: { name: "lodahs", specifier: "1.0.0", field: "dependencies" },
+    version: "1.0.0",
+    registry: "https://registry.npmjs.org/",
+    workspacePolicy: parseWorkspacePolicy(workspace()),
+    fetchImpl: async () => response(200, metadata("lodahs", "1.0.0")),
+    now: NOW
+  };
+  const missingReason = await verifyChangedDependency({
+    ...common,
+    nodePolicy: { typosquatExceptions: [{ package: "lodahs", version: "1.0.0", reason: "" }] }
+  });
+  assert.match(missingReason.join("\n"), /version-scoped/);
+  const reviewed = await verifyChangedDependency({
+    ...common,
+    nodePolicy: { typosquatExceptions: [{ package: "lodahs", version: "1.0.0", reason: "Reviewed synthetic fixture" }] }
+  });
+  assert.deepEqual(reviewed, []);
+  const planted = await verifyChangedDependency({
+    ...common,
+    nodePolicy: { typosquatExceptions: [{ package: "lodahs", version: "1.0.0", reason: "Reviewed synthetic fixture" }] },
+    baseTyposquatExceptions: [{ package: "lodahs", version: "1.0.0", reason: "Reviewed synthetic fixture" }]
+  });
+  assert.match(planted.join("\n"), /added or materially changed in this diff/);
+});
+
+test("removing a protected name cannot authorize its typo in the same diff", async () => {
+  const baseConfig = policyConfig({
+    dependencyPolicy: {
+      node: {
+        minimumReleaseAgeMinutes: 10080,
+        registryTimeoutMilliseconds: 1000,
+        protectedPackageNames: ["synthetic-package"],
+        typosquatExceptions: []
+      },
+      python: { enabled: false, requirementsLockFile: "requirements.lock" }
+    }
+  });
+  const headConfig = policyConfig();
+  const root = syntheticRepo({
+    config: baseConfig,
+    headConfig,
+    headDependencies: { "synthetic-packag": "1.0.0" }
+  });
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: noOpCommand,
+    fetchImpl: async () => response(200, metadata("synthetic-packag", "1.0.0")),
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /protected name 'synthetic-package'/);
+});
+
+test("workspace policy rejects missing hardening and unscoped build permissions", () => {
+  assert.deepEqual(validateWorkspacePolicy(workspace()).errors, []);
+  assert.deepEqual(validateWorkspacePolicy(`# portable policy\n${workspace()}`).errors, []);
+  const errors = validateWorkspacePolicy([
+    "minimumReleaseAge: 1",
+    "blockExoticSubdeps: false",
+    "trustPolicy: off",
+    "strictDepBuilds: false",
+    "dangerouslyAllowAllBuilds: true",
+    "allowBuilds:",
+    "  synthetic-builder: true"
+  ].join("\n")).errors;
+  assert.match(errors.join("\n"), /minimumReleaseAge/);
+  assert.match(errors.join("\n"), /dangerouslyAllowAllBuilds/);
+  assert.match(errors.join("\n"), /exact version/);
+});
+
+test("workspace policy rejects alternate registries, escape hatches, and YAML scalar indirection", () => {
+  const registryErrors = validateWorkspacePolicy(`${workspace()}registry: https://packages.example.invalid/\n`).errors;
+  assert.match(registryErrors.join("\n"), /official npm registry/);
+  const bypassErrors = validateWorkspacePolicy([
+    workspace(),
+    "minimumReleaseAgeExclude:",
+    "  - synthetic-package",
+    "trustPolicyExclude: synthetic-package",
+    "httpsProxy: http://packages.example.invalid/",
+    "ignoredBuiltDependencies:",
+    "  - synthetic-builder"
+  ].join("\n")).errors;
+  assert.match(bypassErrors.join("\n"), /minimumReleaseAgeExclude/);
+  assert.match(bypassErrors.join("\n"), /trustPolicyExclude/);
+  assert.match(bypassErrors.join("\n"), /httpsProxy/);
+  assert.match(bypassErrors.join("\n"), /ignoredBuiltDependencies/);
+  const typedBoolean = validateWorkspacePolicy(workspace().replace(
+    "allowBuilds: {}",
+    "allowBuilds:\n  synthetic-builder@1.2.3: !!bool true"
+  )).errors;
+  assert.match(typedBoolean.join("\n"), /type tags|canonical true\/false/);
+  assert.match(
+    validateWorkspacePolicy(`${workspace()}"dangerouslyAllowAllBuilds": true\n`).errors.join("\n"),
+    /canonical unquoted/
+  );
+  assert.match(
+    validateWorkspacePolicy(`${workspace()}"registry": https:\/\/packages.example.invalid\/\n`).errors.join("\n"),
+    /canonical unquoted/
+  );
+});
+
+test("new allowBuilds permission must match a verified install script", async () => {
+  const root = syntheticRepo({
+    baseWorkspace: workspace(),
+    headWorkspace: workspace(["synthetic-builder@1.2.3"])
+  });
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: noOpCommand,
+    fetchImpl: async () => response(200, metadata("synthetic-builder", "1.2.3")),
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /no install lifecycle script to justify allowBuilds/);
+});
+
+test("project npmrc request routing is rejected before pnpm runs", async () => {
+  const root = syntheticRepo({ npmrc: "https-proxy=http://packages.example.invalid/\n" });
+  let commandCalls = 0;
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: () => {
+      commandCalls += 1;
+      return "";
+    },
+    fetchImpl: async () => response(200, {}),
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /request-routing setting 'https-proxy'/);
+  assert.equal(commandCalls, 0);
+});
+
+test("project npmrc cannot override dependency build policy", async () => {
+  const root = syntheticRepo({ npmrc: "dangerously-allow-all-builds=true\n" });
+  let commandCalls = 0;
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: () => {
+      commandCalls += 1;
+      return "";
+    },
+    fetchImpl: async () => response(200, {}),
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /dependency-policy override 'dangerously-allow-all-builds'/);
+  assert.equal(commandCalls, 0);
+});
+
+test("invalid numeric policy configuration fails instead of weakening checks", async () => {
+  const root = syntheticRepo({
+    config: policyConfig({
+      dependencyPolicy: {
+        node: {
+          minimumReleaseAgeMinutes: "not-a-number",
+          registryTimeoutMilliseconds: 999999,
+          protectedPackageNames: [],
+          typosquatExceptions: []
+        },
+        python: { enabled: false, requirementsLockFile: "requirements.lock" }
+      }
+    })
+  });
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: noOpCommand,
+    fetchImpl: async () => response(200, {}),
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /minimumReleaseAgeMinutes must be an integer/);
+  assert.match(errors.join("\n"), /registryTimeoutMilliseconds must be an integer/);
+});
+
+test("missing or stale pnpm lockfile is blocked", async () => {
+  const missingRoot = syntheticRepo({ headDependencies: { lodash: "4.17.21" }, includeLock: false });
+  const missing = await runDependencyPolicy({
+    root: missingRoot,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: noOpCommand,
+    fetchImpl: async () => response(200, metadata("lodash", "4.17.21")),
+    now: NOW
+  });
+  assert.match(missing.join("\n"), /pnpm-lock.yaml is required/);
+
+  const staleRoot = syntheticRepo({ headDependencies: { lodash: "4.17.21" } });
+  const stale = await runDependencyPolicy({
+    root: staleRoot,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: () => {
+      const error = new Error("frozen lock mismatch");
+      error.stderr = "ERR_PNPM_OUTDATED_LOCKFILE";
+      throw error;
+    },
+    fetchImpl: async () => response(200, metadata("lodash", "4.17.21")),
+    now: NOW
+  });
+  assert.match(stale.join("\n"), /stale.*frozen verification failed/);
+});
+
+test("frozen pnpm verification disables scripts and pnpmfile hooks", async () => {
+  const root = syntheticRepo();
+  let argumentsSeen = [];
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: (_command, args) => {
+      argumentsSeen = args;
+      return "";
+    },
+    fetchImpl: async () => response(200, {}),
+    now: NOW
+  });
+  assert.deepEqual(errors, []);
+  assert.ok(argumentsSeen.includes("--ignore-scripts"));
+  assert.ok(argumentsSeen.includes("--ignore-pnpmfile"));
+});
+
+test("security-critical Node policy files must not be symlinks", async () => {
+  const cases = [
+    ["package.json", `${JSON.stringify({ name: "synthetic" }, null, 2)}\n`],
+    ["pnpm-workspace.yaml", workspace()],
+    ["pnpm-lock.yaml", lockfile()],
+    [".npmrc", "registry=https://registry.npmjs.org/\n"],
+    [".unicorn-hub/config.json", `${JSON.stringify(policyConfig(), null, 2)}\n`]
+  ];
+  for (const [path, content] of cases) {
+    const root = syntheticRepo();
+    mkdirSync(join(root, ".gate-trusted"), { recursive: true });
+    const targetName = path === ".unicorn-hub/config.json" ? "config.json" : path;
+    writeFileSync(join(root, ".gate-trusted", targetName), content);
+    if (existsSync(join(root, path))) unlinkSync(join(root, path));
+    const relativeTarget = path.startsWith(".unicorn-hub/")
+      ? `../.gate-trusted/${targetName}`
+      : `.gate-trusted/${targetName}`;
+    symlinkSync(relativeTarget, join(root, path));
+    git(root, ["add", "-A"]);
+    git(root, ["commit", "-qm", "symlink control file"]);
+    let commandCalls = 0;
+    const errors = await runDependencyPolicy({
+      root,
+      baseRef: "HEAD~1",
+      headRef: "HEAD",
+      runCommand: () => {
+        commandCalls += 1;
+        return "";
+      },
+      fetchImpl: async () => response(200, {}),
+      now: NOW
+    });
+    assert.match(errors.join("\n"), new RegExp(`${path.replaceAll(".", "\\.")}.*regular, non-symlink`), path);
+    assert.equal(commandCalls, 0, path);
+  }
+
+  const root = syntheticRepo();
+  mkdirSync(join(root, ".gate-trusted"), { recursive: true });
+  renameSync(join(root, ".unicorn-hub"), join(root, ".gate-trusted", "config-dir"));
+  symlinkSync(".gate-trusted/config-dir", join(root, ".unicorn-hub"));
+  git(root, ["add", "-A"]);
+  git(root, ["commit", "-qm", "symlink control directory"]);
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: noOpCommand,
+    fetchImpl: async () => response(200, {}),
+    now: NOW
+  });
+  assert.match(errors.join("\n"), /config\.json must be a regular, non-symlink/);
+});
+
+test("only new or changed direct dependencies trigger registry verification", async () => {
+  const root = syntheticRepo({
+    baseDependencies: { lodash: "4.17.21" },
+    headDependencies: { lodash: "4.17.21" }
+  });
+  let fetchCalls = 0;
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: noOpCommand,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return response(200, metadata("lodash", "4.17.21"));
+    },
+    now: NOW
+  });
+  assert.deepEqual(errors, []);
+  assert.equal(fetchCalls, 0);
+});
+
+test("lock-only direct version update triggers exact registry verification", async () => {
+  const root = syntheticRepo({
+    baseDependencies: { lodash: "^4.17.0" },
+    baseLockedVersions: { lodash: "4.17.20" },
+    headDependencies: { lodash: "^4.17.0" },
+    headLockedVersions: { lodash: "4.17.21" }
+  });
+  let verifiedVersion = "";
+  const errors = await runDependencyPolicy({
+    root,
+    baseRef: "HEAD~1",
+    headRef: "HEAD",
+    runCommand: noOpCommand,
+    fetchImpl: async () => {
+      verifiedVersion = "4.17.21";
+      return response(200, metadata("lodash", "4.17.21"));
+    },
+    now: NOW
+  });
+  assert.deepEqual(errors, []);
+  assert.equal(verifiedVersion, "4.17.21");
+});
+
+test("pnpm lock parser resolves direct dependency versions", () => {
+  const parsed = parsePnpmLockImporters(lockfile({ lodash: { specifier: "^4.17.0", version: "4.17.21" } }));
+  assert.equal(parsed.get(".\0dependencies\0lodash"), "4.17.21");
+});
+
+test("pnpm lockfile rejects non-official and exotic package sources", () => {
+  assert.deepEqual(validateLockfileRegistries("resolution: {tarball: https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz}\n"), []);
+  assert.match(
+    validateLockfileRegistries("resolution: {tarball: https://packages.example.invalid/pkg.tgz}\n").join("\n"),
+    /non-official package source/
+  );
+  assert.match(validateLockfileRegistries("resolution: {tarball: file:../pkg.tgz}\n").join("\n"), /Git, local/);
+  assert.match(validateLockfileRegistries("resolution: {repo: ssh://git@example.invalid/pkg}\n").join("\n"), /Git, local/);
+});
+
+test("Python requirement without exact pin or sha256 hash is blocked", () => {
+  const digest = "a".repeat(64);
+  assert.deepEqual(validateHashedRequirements(`synthetic-package==1.2.3 --hash=sha256:${digest}\n`), []);
+  assert.match(validateHashedRequirements("synthetic-package==1.2.3\n").join("\n"), /missing a sha256 hash/);
+  assert.match(validateHashedRequirements(`synthetic-package>=1.2 --hash=sha256:${digest}\n`).join("\n"), /exact == pin/);
+  assert.match(validateHashedRequirements(`synthetic-package==1.* --hash=sha256:${digest}\n`).join("\n"), /exact == pin/);
+  assert.match(
+    validateHashedRequirements(`--index-url https://packages.example.invalid/simple\nsynthetic-package==1.2.3 --hash=sha256:${digest}\n`).join("\n"),
+    /unknown Python index/
+  );
+});
+
+test("Python lock policy applies only to enabled or Python profiles", () => {
+  const root = mkdtempSync(join(tmpdir(), "unicorn-python-policy-"));
+  assert.deepEqual(validatePythonContract(root, policyConfig(), noOpCommand), []);
+  const enabled = policyConfig({
+    profile: "python-service",
+    dependencyPolicy: { node: {}, python: { enabled: true, requirementsLockFile: "requirements.lock" } }
+  });
+  assert.match(validatePythonContract(root, enabled, noOpCommand).join("\n"), /requires uv.lock or hashed requirements.lock/);
+});
+
+test("Python uv contract checks and syncs the locked project", () => {
+  const root = mkdtempSync(join(tmpdir(), "unicorn-python-uv-"));
+  writeFileSync(join(root, "pyproject.toml"), "[project]\nname = \"synthetic-python\"\nversion = \"0.1.0\"\n");
+  writeFileSync(join(root, "uv.lock"), "version = 1\n");
+  const config = policyConfig({
+    profile: "python-service",
+    dependencyPolicy: { node: {}, python: { enabled: true, requirementsLockFile: "requirements.lock" } }
+  });
+  const calls = [];
+  const capture = (command, args) => calls.push([command, ...args]);
+  assert.deepEqual(validatePythonContract(root, config, capture), []);
+  assert.deepEqual(syncPythonContract(root, config, capture), []);
+  assert.deepEqual(calls, [
+    ["uv", "lock", "--check"],
+    ["uv", "sync", "--locked"]
+  ]);
+});
+
+test("Python uv contract rejects direct Git, URL, and local sources", () => {
+  const config = policyConfig({
+    profile: "python-service",
+    dependencyPolicy: { node: {}, python: { enabled: true, requirementsLockFile: "requirements.lock" } }
+  });
+  const pyprojectRoot = mkdtempSync(join(tmpdir(), "unicorn-python-uv-direct-"));
+  writeFileSync(join(pyprojectRoot, "pyproject.toml"), [
+    "[project]",
+    "name = \"synthetic-python\"",
+    "version = \"0.1.0\"",
+    "dependencies = [\"synthetic-package @ git+https://example.invalid/package.git\"]",
+    ""
+  ].join("\n"));
+  writeFileSync(join(pyprojectRoot, "uv.lock"), "version = 1\nsource = { editable = \".\" }\n");
+  assert.match(validatePythonContract(pyprojectRoot, config, noOpCommand).join("\n"), /forbidden direct Git/);
+
+  const lockRoot = mkdtempSync(join(tmpdir(), "unicorn-python-uv-lock-source-"));
+  writeFileSync(join(lockRoot, "pyproject.toml"), "[project]\nname = \"synthetic-python\"\nversion = \"0.1.0\"\n");
+  writeFileSync(join(lockRoot, "uv.lock"), "version = 1\nsource = { git = \"https://example.invalid/package.git\" }\n");
+  assert.match(validatePythonContract(lockRoot, config, noOpCommand).join("\n"), /uv\.lock contains a forbidden/);
+});
+
+test("hashed Python contract uses require-hashes and binary-only install", () => {
+  const root = mkdtempSync(join(tmpdir(), "unicorn-python-hashes-"));
+  writeFileSync(
+    join(root, "requirements.lock"),
+    `synthetic-package==1.2.3 --hash=sha256:${"b".repeat(64)}\n`
+  );
+  const config = policyConfig({
+    profile: "python-service",
+    commands: { install: "python -m pip --isolated install --index-url https://pypi.org/simple --require-hashes --only-binary :all: -r requirements.lock" },
+    dependencyPolicy: { node: {}, python: { enabled: true, requirementsLockFile: "requirements.lock" } }
+  });
+  const calls = [];
+  const capture = (command, args) => calls.push([command, ...args]);
+  assert.deepEqual(validatePythonContract(root, config, capture), []);
+  assert.deepEqual(syncPythonContract(root, config, capture), []);
+  assert.deepEqual(calls, [[
+    "python", "-m", "pip", "--isolated", "install", "--index-url", "https://pypi.org/simple",
+    "--require-hashes", "--only-binary", ":all:", "-r", "requirements.lock"
+  ]]);
+});
+
+test("hashed Python lock path cannot escape the repository", () => {
+  const root = mkdtempSync(join(tmpdir(), "unicorn-python-path-"));
+  const config = policyConfig({
+    profile: "python-service",
+    commands: { install: "python -m pip --isolated install --index-url https://pypi.org/simple --require-hashes --only-binary :all: -r ../requirements.lock" },
+    dependencyPolicy: { node: {}, python: { enabled: true, requirementsLockFile: "../requirements.lock" } }
+  });
+  assert.match(validatePythonContract(root, config, noOpCommand).join("\n"), /repository-relative file path/);
+  assert.match(syncPythonContract(root, config, noOpCommand).join("\n"), /regular, non-symlink repository file/);
+});
+
+test("hashed Python lock must not be a symlink or leak rejected requirement content", () => {
+  const root = mkdtempSync(join(tmpdir(), "unicorn-python-symlink-"));
+  const external = join(tmpdir(), `synthetic-requirements-${Date.now()}.lock`);
+  writeFileSync(external, "private-token-value\n");
+  symlinkSync(external, join(root, "requirements.lock"));
+  const config = policyConfig({
+    profile: "python-service",
+    commands: { install: "python -m pip --isolated install --index-url https://pypi.org/simple --require-hashes --only-binary :all: -r requirements.lock" },
+    dependencyPolicy: { node: {}, python: { enabled: true, requirementsLockFile: "requirements.lock" } }
+  });
+  const errors = validatePythonContract(root, config, noOpCommand);
+  assert.match(errors.join("\n"), /regular, non-symlink repository file/);
+  assert.doesNotMatch(errors.join("\n"), /private-token-value/);
+  unlinkSync(external);
+});

--- a/tests/workflows.test.mjs
+++ b/tests/workflows.test.mjs
@@ -25,12 +25,13 @@ test("root Dependabot configuration stays in sync with its template", () => {
 test("CI requires a frozen pnpm lockfile without an unsafe fallback", () => {
   const workflow = readFileSync(join(root, ".github", "workflows", "ci.yml"), "utf8");
   assert.match(workflow, /pnpm install --frozen-lockfile/);
+  assert.match(workflow, /pnpm install --frozen-lockfile --ignore-scripts --ignore-pnpmfile/);
   assert.match(workflow, /version: 10\.34\.5/);
   assert.doesNotMatch(workflow, /--no-frozen-lockfile/);
   assert.doesNotMatch(workflow, /if \[ -f pnpm-lock\.yaml \]/);
   assert.ok(
     workflow.indexOf("pnpm run check:repo") < workflow.indexOf("pnpm install --frozen-lockfile"),
-    "the pinned pnpm baseline must pass before dependency lifecycle scripts can run"
+    "the pinned pnpm baseline must pass before dependency installation"
   );
 });
 

--- a/tests/workflows.test.mjs
+++ b/tests/workflows.test.mjs
@@ -21,3 +21,25 @@ test("root Dependabot configuration stays in sync with its template", () => {
 
   assert.equal(rootConfig, templateConfig);
 });
+
+test("CI requires a frozen pnpm lockfile without an unsafe fallback", () => {
+  const workflow = readFileSync(join(root, ".github", "workflows", "ci.yml"), "utf8");
+  assert.match(workflow, /pnpm install --frozen-lockfile/);
+  assert.match(workflow, /version: 10\.34\.5/);
+  assert.doesNotMatch(workflow, /--no-frozen-lockfile/);
+  assert.doesNotMatch(workflow, /if \[ -f pnpm-lock\.yaml \]/);
+  assert.ok(
+    workflow.indexOf("pnpm run check:repo") < workflow.indexOf("pnpm install --frozen-lockfile"),
+    "the pinned pnpm baseline must pass before dependency lifecycle scripts can run"
+  );
+});
+
+test("dependency policy remains inside the existing PR Guard context", () => {
+  const workflow = readFileSync(join(root, ".github", "workflows", "pr-guard.yml"), "utf8");
+  assert.match(workflow, /jobs:\n  guard:\n    name: guard/);
+  assert.match(workflow, /check-dependency-policy\.mjs --sync-python/);
+  assert.match(workflow, /pnpm\/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1/);
+  assert.match(workflow, /version: 10\.34\.5/);
+  assert.match(workflow, /astral-sh\/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d/);
+  assert.doesNotMatch(workflow, /^  dependency-policy:/m);
+});


### PR DESCRIPTION
## Summary

- harden root and bootstrapped pnpm policy with frozen locks, release-age/provenance controls, strict dependency builds, and exact-version `allowBuilds`
- add a portable fail-closed dependency-policy checker to the existing PR Guard for changed direct dependencies, registry identity/version/age, lightweight typo and Unicode detection, reviewed exceptions, and install-script approval
- add profile-scoped locked Python contracts for uv and isolated hash-checked pip, plus bootstrap propagation, documentation, and synthetic regression coverage

## Security boundary

- rejects Git, URL, archive, local, unknown-registry, request-routing, lock-source, YAML-indirection, and symlink-laundering bypasses before invoking pnpm
- keeps registry metadata checks limited to changed direct dependencies and newly granted build permissions; no popularity database or reputation service
- does not change GitHub security settings or branch protection

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/check-dependency-policy.mjs origin/main HEAD`
- `pnpm run preflight` — sanitizer, baseline, workflow sync, syntax, synthetic bootstrap, and 93/93 tests passed
- independent code and architecture reviews: approved with no remaining blocking findings

Co-authored-by: Codex <codex@openai.com>
