### PR TITLE
fix: accept Dependabot security status responses

### DIFF
--- a/docs/github-ci-and-branch-protection.md
+++ b/docs/github-ci-and-branch-protection.md
@@ -102,6 +102,12 @@ those optional capabilities as unsupported when GitHub rejects them for
 availability reasons. Authentication, permission, and unexpected API failures
 remain real errors.
 
+Dependabot security updates are only treated as enabled when GitHub reports them
+as enabled and not paused. A paused repository is planned for remediation under
+`--dry-run` and re-enabled under `--apply`; if GitHub still reports the feature
+as paused after the update, activation fails closed and branch protection is not
+applied.
+
 When invoked with `--apply`, `scripts/apply-branch-protection.mjs` sets required human approvals
 to `0`. This keeps the solo-owner workflow usable while still requiring green
 checks, AI review evidence, and conversation resolution. Repositories with more

--- a/scripts/apply-security-settings.mjs
+++ b/scripts/apply-security-settings.mjs
@@ -38,8 +38,13 @@ const definitions = [
     kind: "endpoint",
     readPath: `/repos/${repo}/automated-security-fixes`,
     writePath: `/repos/${repo}/automated-security-fixes`,
-    enabled: (response) => response.status === 204 || (response.ok && response.json?.enabled === true),
-    disabled: (response) => response.status === 404 || (response.ok && response.json?.enabled === false)
+    enabled: (response) =>
+      response.status === 204 || (response.ok && response.json?.enabled === true && response.json?.paused !== true),
+    disabled: (response) =>
+      response.status === 404 ||
+      (response.ok && response.json?.enabled === false) ||
+      (response.ok && response.json?.paused === true),
+    note: (response) => (response?.ok && response.json?.paused === true ? "GitHub has paused this feature" : "")
   },
   {
     id: "secret-scanning",
@@ -70,6 +75,11 @@ const definitions = [
     key: "secret_scanning_non_provider_patterns"
   }
 ];
+
+function annotate(definition, response, message) {
+  const note = definition.note?.(response) || "";
+  return note ? `${message} (${note})` : message;
+}
 
 function unavailable(response) {
   if (![403, 422].includes(response.status)) return false;
@@ -131,7 +141,7 @@ for (const definition of definitions) {
     continue;
   }
   if (dryRun) {
-    console.log(`[planned] ${definition.label}: would enable`);
+    console.log(annotate(definition, current.response, `[planned] ${definition.label}: would enable`));
     outcomes.set(definition.id, "planned");
     continue;
   }
@@ -147,7 +157,13 @@ for (const definition of definitions) {
   repositoryState = readRepository();
   const verified = readFeature(definition, repositoryState);
   if (verified.state !== "enabled") {
-    console.error(`[failed] ${definition.label}: GitHub accepted the update but the enabled state could not be verified`);
+    console.error(
+      annotate(
+        definition,
+        verified.response,
+        `[failed] ${definition.label}: GitHub accepted the update but the enabled state could not be verified`
+      )
+    );
     outcomes.set(definition.id, "failed");
     continue;
   }

--- a/scripts/apply-security-settings.mjs
+++ b/scripts/apply-security-settings.mjs
@@ -38,8 +38,8 @@ const definitions = [
     kind: "endpoint",
     readPath: `/repos/${repo}/automated-security-fixes`,
     writePath: `/repos/${repo}/automated-security-fixes`,
-    enabled: (response) => response.status === 204,
-    disabled: (response) => response.status === 404
+    enabled: (response) => response.status === 204 || (response.ok && response.json?.enabled === true),
+    disabled: (response) => response.status === 404 || (response.ok && response.json?.enabled === false)
   },
   {
     id: "secret-scanning",

--- a/specs/018-github-security-activation/plan.md
+++ b/specs/018-github-security-activation/plan.md
@@ -49,10 +49,12 @@ Extend the existing Dependabot renderer and OSV workflow contract, add a small t
 | AC-008 | Bootstrap file and ordered `Next:` output assertions. |
 | AC-009–AC-010 | Branch-protection tests proving checks are queried before PUT and missing contexts block mutation. |
 | AC-011 | Documentation content assertions and manual review. |
+| AC-012 | Synthetic `gh` coverage for JSON-state and no-content Dependabot security-update responses, plus a live repository dry-run. |
 
 Negative scenario evidence:
 
 - Run focused security, bootstrap, and workflow tests for NS-001 through NS-007.
+- Run the live dry-run and focused response-shape regression for NS-008.
 - Run `pnpm run preflight` for the complete repository contract.
 
 ## Risks

--- a/specs/018-github-security-activation/plan.md
+++ b/specs/018-github-security-activation/plan.md
@@ -50,11 +50,13 @@ Extend the existing Dependabot renderer and OSV workflow contract, add a small t
 | AC-009–AC-010 | Branch-protection tests proving checks are queried before PUT and missing contexts block mutation. |
 | AC-011 | Documentation content assertions and manual review. |
 | AC-012 | Synthetic `gh` coverage for JSON-state and no-content Dependabot security-update responses, plus a live repository dry-run. |
+| AC-013 | Synthetic `gh` coverage for a paused security-update response across dry-run, successful resume, and stays-paused remediation. |
 
 Negative scenario evidence:
 
 - Run focused security, bootstrap, and workflow tests for NS-001 through NS-007.
 - Run the live dry-run and focused response-shape regression for NS-008.
+- Run the paused-state regressions for NS-009, including the stays-paused case that must exit non-zero without applying branch protection.
 - Run `pnpm run preflight` for the complete repository contract.
 
 ## Risks

--- a/specs/018-github-security-activation/spec.md
+++ b/specs/018-github-security-activation/spec.md
@@ -53,6 +53,7 @@ As a maintainer applying branch protection, I want required checks verified on t
 - AC-010: Branch protection refuses to mutate GitHub when any configured required check is absent.
 - AC-011: Portable DevOps documentation includes a concise incident-response checklist covering reinfection containment, secret rotation, GitHub/registry/SSH/integration tokens, verified-backup recovery, multiple backup generations, and one immutable copy.
 - AC-012: Dependabot security-update state accepts both GitHub response shapes observed in production: `200` with an `enabled` boolean and the compatible `204`/`404` no-content form.
+- AC-013: Dependabot security updates count as enabled only when GitHub reports them enabled and not paused; a paused repository is remediated and re-verified before branch protection is attempted.
 
 ## Negative Scenarios
 
@@ -64,6 +65,7 @@ As a maintainer applying branch protection, I want required checks verified on t
 - NS-006: Branch protection is not applied when one or more configured status contexts have never appeared on the default branch.
 - NS-007: `github-actions` output never contains unsupported semver cooldown fields, and major updates never enter the minor/patch group.
 - NS-008: A disabled `200 {"enabled":false}` security-update response is planned for enablement instead of being misclassified as an API failure.
+- NS-009: A paused `200 {"enabled":true,"paused":true}` security-update response never reports the feature as enabled; if it stays paused after remediation, activation fails closed and branch protection is not applied.
 
 ## Requirements
 

--- a/specs/018-github-security-activation/spec.md
+++ b/specs/018-github-security-activation/spec.md
@@ -52,6 +52,7 @@ As a maintainer applying branch protection, I want required checks verified on t
 - AC-009: Successful activation applies branch protection from `.unicorn-hub/config.json` only after the workflows are present on the default branch and all required check contexts have appeared in recent repository runs.
 - AC-010: Branch protection refuses to mutate GitHub when any configured required check is absent.
 - AC-011: Portable DevOps documentation includes a concise incident-response checklist covering reinfection containment, secret rotation, GitHub/registry/SSH/integration tokens, verified-backup recovery, multiple backup generations, and one immutable copy.
+- AC-012: Dependabot security-update state accepts both GitHub response shapes observed in production: `200` with an `enabled` boolean and the compatible `204`/`404` no-content form.
 
 ## Negative Scenarios
 
@@ -62,6 +63,7 @@ As a maintainer applying branch protection, I want required checks verified on t
 - NS-005: A profile that excludes `osv-scan.yml` does not acquire an impossible `osv-scan` required check.
 - NS-006: Branch protection is not applied when one or more configured status contexts have never appeared on the default branch.
 - NS-007: `github-actions` output never contains unsupported semver cooldown fields, and major updates never enter the minor/patch group.
+- NS-008: A disabled `200 {"enabled":false}` security-update response is planned for enablement instead of being misclassified as an API failure.
 
 ## Requirements
 

--- a/specs/018-github-security-activation/tasks.md
+++ b/specs/018-github-security-activation/tasks.md
@@ -31,6 +31,8 @@
 - [x] T021 Resolve Codex P1 by rendering CI and OSV push filters for the configured or discovered default branch, with regression coverage and updated install docs.
 - [x] T022 Resolve Codex P2 by rendering the branch as a JSON-compatible YAML scalar, including valid Git branch names that contain a double quote.
 - [x] T023 Resolve Codex P1 by binding PR-only evidence to the workflow blob now on the default branch instead of requiring the run to postdate the merge commit.
+- [x] T024 Reproduce the post-merge Dependabot security-update status response against the live repository and preserve the no-mutation failure evidence.
+- [x] T025 Accept both JSON-state and no-content status responses and add focused regression coverage.
 
 ## Process Memory
 
@@ -38,6 +40,7 @@
 
 - Validating every required context only on the current `main` head rejected real PR-only checks (`guard`, `AI Review`). The activation now proves push-oriented and consumer-defined CI on the current default head, while proving Unicorn's PR-only jobs through workflow-specific pull-request runs created after that workflow version reached the default branch.
 - The first live dry-run exceeded Node's default synchronous subprocess buffer while reading GitHub responses. GitHub CLI response capture now uses a bounded 16 MiB buffer, workflow-scoped queries, and early exit as soon as each workflow's configured contexts are proven.
+- The first post-merge live dry-run exposed `200 {"enabled":false,"paused":false}` from the Dependabot security-update endpoint, while the merged compatibility path expected only `204`/`404`. Activation failed closed and made no changes; the status classifier now accepts both response contracts.
 
 ### Decisions
 

--- a/specs/018-github-security-activation/tasks.md
+++ b/specs/018-github-security-activation/tasks.md
@@ -33,6 +33,7 @@
 - [x] T023 Resolve Codex P1 by binding PR-only evidence to the workflow blob now on the default branch instead of requiring the run to postdate the merge commit.
 - [x] T024 Reproduce the post-merge Dependabot security-update status response against the live repository and preserve the no-mutation failure evidence.
 - [x] T025 Accept both JSON-state and no-content status responses and add focused regression coverage.
+- [x] T026 Resolve Codex P1 by refusing to treat a paused Dependabot security-update state as enabled, remediating it, and failing closed when it stays paused.
 
 ## Process Memory
 
@@ -41,6 +42,7 @@
 - Validating every required context only on the current `main` head rejected real PR-only checks (`guard`, `AI Review`). The activation now proves push-oriented and consumer-defined CI on the current default head, while proving Unicorn's PR-only jobs through workflow-specific pull-request runs created after that workflow version reached the default branch.
 - The first live dry-run exceeded Node's default synchronous subprocess buffer while reading GitHub responses. GitHub CLI response capture now uses a bounded 16 MiB buffer, workflow-scoped queries, and early exit as soon as each workflow's configured contexts are proven.
 - The first post-merge live dry-run exposed `200 {"enabled":false,"paused":false}` from the Dependabot security-update endpoint, while the merged compatibility path expected only `204`/`404`. Activation failed closed and made no changes; the status classifier now accepts both response contracts.
+- Accepting the JSON state shape initially read only the `enabled` flag, so a paused repository would have satisfied a mandatory protection without it being active. The classifier now requires `paused !== true`, remediates the paused state, and reports the paused reason on both the planned and the unverified outcome.
 
 ### Decisions
 

--- a/tests/security-settings.test.mjs
+++ b/tests/security-settings.test.mjs
@@ -38,7 +38,10 @@ if (path === repoPath + "/vulnerability-alerts") {
   state.vulnerabilityAlerts = true; save(); reply(204);
 }
 if (path === repoPath + "/automated-security-fixes") {
-  if (method === "GET") reply(state.automatedSecurityFixes ? 204 : 404, state.automatedSecurityFixes ? null : { message: "Disabled" });
+  if (method === "GET" && state.securityUpdatesStatusStyle === "no-content") {
+    reply(state.automatedSecurityFixes ? 204 : 404, state.automatedSecurityFixes ? null : { message: "Disabled" });
+  }
+  if (method === "GET") reply(200, { enabled: state.automatedSecurityFixes, paused: false });
   if (state.failEndpoint === "automated-security-fixes") reply(500, { message: "Synthetic API failure" });
   state.automatedSecurityFixes = true; save(); reply(204);
 }
@@ -205,7 +208,15 @@ test("security activation dry-run performs no mutations", () => {
   assert.equal(state.calls.some((call) => ["PATCH", "PUT", "DELETE"].includes(call.method)), false);
   assert.equal(state.protectionApplied, false);
   assert.match(result.stdout, /Dry run: no GitHub settings were changed/);
+  assert.match(result.stdout, /\[planned\] Dependabot security updates: would enable/);
   assert.match(result.stdout, /Would apply branch protection/);
+});
+
+test("security-update status accepts the no-content compatibility response", () => {
+  const value = fixture({ automatedSecurityFixes: true, securityUpdatesStatusStyle: "no-content" });
+  const result = runSecurity("--dry-run", value);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Dependabot security updates: already enabled/);
 });
 
 test("security activation is idempotent and applies branch protection after verification", () => {

--- a/tests/security-settings.test.mjs
+++ b/tests/security-settings.test.mjs
@@ -41,9 +41,11 @@ if (path === repoPath + "/automated-security-fixes") {
   if (method === "GET" && state.securityUpdatesStatusStyle === "no-content") {
     reply(state.automatedSecurityFixes ? 204 : 404, state.automatedSecurityFixes ? null : { message: "Disabled" });
   }
-  if (method === "GET") reply(200, { enabled: state.automatedSecurityFixes, paused: false });
+  if (method === "GET") reply(200, { enabled: state.automatedSecurityFixes, paused: Boolean(state.securityUpdatesPaused) });
   if (state.failEndpoint === "automated-security-fixes") reply(500, { message: "Synthetic API failure" });
-  state.automatedSecurityFixes = true; save(); reply(204);
+  state.automatedSecurityFixes = true;
+  if (!state.securityUpdatesStayPaused) state.securityUpdatesPaused = false;
+  save(); reply(204);
 }
 if (method === "PATCH" && path === repoPath) {
   const key = Object.keys(body.security_and_analysis)[0];
@@ -217,6 +219,38 @@ test("security-update status accepts the no-content compatibility response", () 
   const result = runSecurity("--dry-run", value);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Dependabot security updates: already enabled/);
+});
+
+test("paused security updates are planned for remediation instead of reported as enabled", () => {
+  const value = fixture({ automatedSecurityFixes: true, securityUpdatesPaused: true });
+  const result = runSecurity("--dry-run", value);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(stateOf(value).calls.some((call) => ["PATCH", "PUT", "DELETE"].includes(call.method)), false);
+  assert.match(result.stdout, /\[planned\] Dependabot security updates: would enable \(GitHub has paused this feature\)/);
+  assert.doesNotMatch(result.stdout, /Dependabot security updates: already enabled/);
+});
+
+test("paused security updates are resumed and verified during apply", () => {
+  const value = fixture({ automatedSecurityFixes: true, securityUpdatesPaused: true });
+  const result = runSecurity("--apply", value);
+  assert.equal(result.status, 0, result.stderr);
+  const state = stateOf(value);
+  assert.equal(state.securityUpdatesPaused, false);
+  assert.equal(state.protectionApplied, true);
+  assert.match(result.stdout, /\[enabled\] Dependabot security updates: enabled and verified/);
+});
+
+test("security updates that stay paused fail closed before branch protection", () => {
+  const value = fixture({
+    automatedSecurityFixes: true,
+    securityUpdatesPaused: true,
+    securityUpdatesStayPaused: true
+  });
+  const result = runSecurity("--apply", value);
+  assert.equal(result.status, 1);
+  assert.equal(stateOf(value).protectionApplied, false);
+  assert.match(result.stderr, /Dependabot security updates: GitHub accepted the update but the enabled state could not be verified \(GitHub has paused this feature\)/);
+  assert.match(result.stderr, /branch protection was not changed/);
 });
 
 test("security activation is idempotent and applies branch protection after verification", () => {


### PR DESCRIPTION
## Summary

- accept the live GitHub `200` JSON state returned by the automated-security-fixes endpoint
- retain compatibility with the `204`/`404` response form
- add regression coverage and record the post-merge dry-run evidence

## Verification

- focused security activation tests: 22 passed
- full `pnpm run preflight`: 123 tests passed; sanitizer, baseline, workflow sync, syntax, and bootstrap passed
- corrected live `--dry-run`: all six settings planned and all required checks proven; no remote mutations

## Activation note

Do not run `--apply` until this fix is merged into `main`.

Co-authored-by: Codex <codex@openai.com>